### PR TITLE
fix sql script as file was encoded as UTF-8 Unicode (with BOM) text

### DIFF
--- a/ordinary_data/08_valve/02_tr_valve_pipe.sql
+++ b/ordinary_data/08_valve/02_tr_valve_pipe.sql
@@ -1,4 +1,4 @@
-﻿/*
+/*
 	qWat - QGIS Water Module
 	
 	SQL file :: valve-pipe functions and rules


### PR DESCRIPTION
sql was not working as  02_tr_valve_pipe.sql was encoded as "UTF-8 Unicode (with BOM) text".
When executing the create_schemas, '<feff>' was appearing out of nowhere in the code.

Script used: http://thegreyblog.blogspot.ro/2010/09/shell-script-to-find-and-remove-bom.html

Good morning and all the best.