### PR TITLE
Valve refactoring take 2

### DIFF
--- a/ordinary_data/08_valve/01_od_valve.sql
+++ b/ordinary_data/08_valve/01_od_valve.sql
@@ -12,21 +12,24 @@ COMMENT ON TABLE qwat_od.valve IS 'Table for valve.';
 
 /* columns */
 ALTER TABLE qwat_od.valve ADD COLUMN identification    varchar(20) ;
-ALTER TABLE qwat_od.valve ADD COLUMN fk_distributor    integer not null      ;
-ALTER TABLE qwat_od.valve ADD COLUMN fk_type           integer not null ;
-ALTER TABLE qwat_od.valve ADD COLUMN fk_function       integer not null ;
-ALTER TABLE qwat_od.valve ADD COLUMN fk_status         integer not null ;
-ALTER TABLE qwat_od.valve ADD COLUMN fk_actuation      integer not null ;
-ALTER TABLE qwat_od.valve ADD COLUMN fk_precision      integer not null ;
-ALTER TABLE qwat_od.valve ADD COLUMN fk_precisionalti  integer not null ;
-ALTER TABLE qwat_od.valve ADD COLUMN fk_maintenance    integer[];
-ALTER TABLE qwat_od.valve ADD COLUMN fk_locationtype   integer[];
-ALTER TABLE qwat_od.valve ADD COLUMN diameter_nominal  varchar(10) ;
-ALTER TABLE qwat_od.valve ADD COLUMN year              smallint CHECK (year IS NULL OR year > 1800 AND year < 2100);
-ALTER TABLE qwat_od.valve ADD COLUMN closed            boolean       default false ;
-ALTER TABLE qwat_od.valve ADD COLUMN networkseparation boolean       default false ;
-ALTER TABLE qwat_od.valve ADD COLUMN altitude_real     decimal(10,3)  ;
-ALTER TABLE qwat_od.valve ADD COLUMN remark            text          ;
+ALTER TABLE qwat_od.valve ADD COLUMN fk_distributor    		integer not null      ;
+ALTER TABLE qwat_od.valve ADD COLUMN fk_type           		integer not null ;
+ALTER TABLE qwat_od.valve ADD COLUMN fk_function       		integer not null ;
+ALTER TABLE qwat_od.valve ADD COLUMN fk_status         		integer not null ;
+ALTER TABLE qwat_od.valve ADD COLUMN fk_actuation      		integer not null ;
+ALTER TABLE qwat_od.valve ADD COLUMN fk_precision      		integer not null ;
+ALTER TABLE qwat_od.valve ADD COLUMN fk_precisionalti  		integer not null ;
+ALTER TABLE qwat_od.valve ADD COLUMN fk_maintenance    		integer[];
+ALTER TABLE qwat_od.valve ADD COLUMN fk_locationtype 		integer[];
+ALTER TABLE qwat_od.valve ADD COLUMN fk_handle_precision      	integer ;
+ALTER TABLE qwat_od.valve ADD COLUMN fk_handle_precisionalti	integer ;
+ALTER TABLE qwat_od.valve ADD COLUMN diameter_nominal 		varchar(10) ;
+ALTER TABLE qwat_od.valve ADD COLUMN year              		smallint CHECK (year IS NULL OR year > 1800 AND year < 2100);
+ALTER TABLE qwat_od.valve ADD COLUMN closed            		boolean  	default false ;
+ALTER TABLE qwat_od.valve ADD COLUMN networkseparation 		boolean       	default false ;
+ALTER TABLE qwat_od.valve ADD COLUMN altitude_real     		decimal(10,3)  ;
+ALTER TABLE qwat_od.valve ADD COLUMN handle_altitude_real     	decimal(10,3)  ;
+ALTER TABLE qwat_od.valve ADD COLUMN remark 			text ;
 
 /* schema view */
 SELECT qwat_od.fn_enable_schemaview('valve');

--- a/value_lists/vl_valve_function.sql
+++ b/value_lists/vl_valve_function.sql
@@ -23,8 +23,13 @@ INSERT INTO qwat_vl.valve_function (id, value_fr, value_ro, schema_visible ) 	VA
 INSERT INTO qwat_vl.valve_function (id, value_fr, value_ro )                 	VALUES (6106,'prise de secours','');
 INSERT INTO qwat_vl.valve_function (id, value_fr, value_ro )                 	VALUES (6107,'vanne incendie','vană incendiu');
 INSERT INTO qwat_vl.valve_function (id, value_fr, value_ro )                 	VALUES (6108,'vanne d''hydrant','vană hidrant');
-INSERT INTO qwat_vl.valve_function (id, value_fr, value_ro )                 	VALUES (6109,'inconnu','necunoscut');
+
 INSERT INTO qwat_vl.valve_function (id, value_fr, short_fr,value_ro )        	VALUES (6110,'vidange','Vi','vană golire');
 INSERT INTO qwat_vl.valve_function (id, value_fr, value_ro)                  	VALUES (6111,'vanne réseau','vană cu sertar');
 INSERT INTO qwat_vl.valve_function (id, value_fr, short_fr, value_ro)        	VALUES (6112,'vidange-ventouse','ViVe','golire-aerisire');
-INSERT INTO qwat_vl.valve_function (id, value_en, value_fr, short_fr, value_ro) VALUES (6113, 'backflow prevention', 'antirefoulement','','antiretur');
+INSERT INTO qwat_vl.valve_function (id, value_en, value_fr, value_ro)  		VALUES (6113, 'backflow prevention', 'antirefoulement',	   'antiretur');
+INSERT INTO qwat_vl.valve_function (id, value_en, value_fr, value_ro ) 		VALUES (6314, 'shut-off valve',     'arrêt',                'oprire');
+INSERT INTO qwat_vl.valve_function (id, value_en, value_fr, value_ro ) 		VALUES (6315, 'vent valve',         'jauge',                'aerisire');
+INSERT INTO qwat_vl.valve_function (id, value_en, value_fr, value_ro ) 		VALUES (10001, 'other', 'autre', 'alta');
+INSERT INTO qwat_vl.valve_function (id, value_en, value_fr, value_ro ) 		VALUES (10002, 'unknown', 'inconnu', 'necunoscută');
+INSERT INTO qwat_vl.valve_function (id, value_en, value_fr, value_ro ) 		VALUES (10003, 'to be determined', 'à déterminer', 'de determinat');

--- a/value_lists/vl_valve_type.sql
+++ b/value_lists/vl_valve_type.sql
@@ -12,16 +12,17 @@ ALTER TABLE qwat_vl.valve_type ADD CONSTRAINT vl_valve_type_pk PRIMARY KEY (id);
 COMMENT ON TABLE qwat_vl.valve_type IS 'Types of valve';
 
 /* COLUMNS */
+INSERT INTO qwat_vl.valve_type ( id, value_en, value_fr, value_ro ) VALUES (6301, 'gate valve',		'vanne à opercule',	'vană cu sertar');
+INSERT INTO qwat_vl.valve_type ( id, value_en, value_fr, value_ro ) VALUES (6302, 'clayton valve',	'vanne clayton',	'vană clayton');
+INSERT INTO qwat_vl.valve_type ( id, value_en, value_fr, value_ro ) VALUES (6303, 'annular valve',	'vanne annulaire',	'vană inelară');
 
-INSERT INTO qwat_vl.valve_type ( id, value_fr, value_ro ) VALUES (6302, 'vanne clayton',	'vană clayton');
-INSERT INTO qwat_vl.valve_type ( id, value_fr, value_ro ) VALUES (6303, 'vanne annulaire',	'vană inelară');
-INSERT INTO qwat_vl.valve_type ( id, value_fr, value_ro ) VALUES (6304, 'inconnu',		'necunoscut');
-INSERT INTO qwat_vl.valve_type ( id, value_fr, value_ro ) VALUES (6305, 'jauge',		'aerisire');
-INSERT INTO qwat_vl.valve_type ( id, value_fr, value_ro ) VALUES (6306, 'limiteur de débit',	'reductor');
-INSERT INTO qwat_vl.valve_type ( id, value_fr, value_ro ) VALUES (6307, 'vanne clapet',         'vană clapet');
-INSERT INTO qwat_vl.valve_type ( id, value_fr, value_ro ) VALUES (6308, 'soupape automatique', 	'supapă automatică');
-INSERT INTO qwat_vl.valve_type ( id, value_fr, value_ro ) VALUES (6309, 'sprinkler',		'sprinkler');
-INSERT INTO qwat_vl.valve_type ( id, value_fr, value_ro ) VALUES (6310, 'vanne',		'vană');
-INSERT INTO qwat_vl.valve_type ( id, value_fr, short_fr, value_ro ) VALUES (6311, 'vanne papillon', 'P','vană fluture');
-INSERT INTO qwat_vl.valve_type ( id, value_fr, value_ro ) VALUES (6312, 'Elgef',		'Elgef');
-INSERT INTO qwat_vl.valve_type ( id, value_fr, value_ro ) VALUES (6313, 'arrêt',		'oprire');
+INSERT INTO qwat_vl.valve_type ( id, value_en, value_fr, value_ro ) VALUES (6306, 'flow control valve',	'limiteur de débit',	'reductor');
+INSERT INTO qwat_vl.valve_type ( id, value_en, value_fr, value_ro ) VALUES (6307, 'check valve',	'vanne clapet',         'vană cu clapetă');
+INSERT INTO qwat_vl.valve_type ( id, value_en, value_fr, value_ro ) VALUES (6308, '',			'soupape automatique', 	'supapă automată');
+INSERT INTO qwat_vl.valve_type ( id, value_en, value_fr, value_ro ) VALUES (6309, '',			'sprinkler',		'sprinkler');
+INSERT INTO qwat_vl.valve_type ( id, value_en, value_fr, value_ro ) VALUES (6310, 'valve',		'vanne',		'vană');
+INSERT INTO qwat_vl.valve_type ( id, value_en, value_fr, short_fr, value_ro ) VALUES (6311, 'butterfly valve',	'vanne papillon', 'P','vană fluture');
+INSERT INTO qwat_vl.valve_type ( id, value_en, value_fr, value_ro ) VALUES (6312, '',			'Elgef',		'Elgef');
+INSERT INTO qwat_vl.valve_type (id, value_en, value_fr, value_ro )  VALUES (10001, 'other', 'autre', 'alta');
+INSERT INTO qwat_vl.valve_type (id, value_en, value_fr, value_ro )  VALUES (10002, 'unknown', 'inconnu', 'necunoscut');
+INSERT INTO qwat_vl.valve_type (id, value_en, value_fr, value_ro )  VALUES (10003, 'to be determined', 'à déterminer', 'de determinat');


### PR DESCRIPTION
Hello again,

I added the:
- handle_altitude_real
- handle_precision
- handle_precisionalti 
columns for the valve handle in order to avoid a possible problem where users could mistakenly think that the altitude_real, precision and precisionalti columns refer to the handle and not the actual valve-node.
After I get your ok on this will also make a pull for the valve ui. 
Also, I will need to create some check constraints so that in the case the handle_geometry is present --> non-null values in the handle precision columns.

Regarding valve types, I simply added the "gate valve" in the value list + filled english values.
However, I am proposing to also move the shut-off/arrêt and the "vent/jauge" valves from type to function. Thoughts on this?

It's also clear to me that the valves still need some refactoring and I'm waiting for the others qwat users to join in and make proposals.
I think that in the end we shall end up with a Qlist widget for valves_function as I believe there are some cases where we need to input multiple functions for a valve. I suppose we could even end up with a similar solution as for the pipe materials.

All the best!

