### PR TITLE
Installation buildings

### DIFF
--- a/ordinary_data/10_installation/0_od_installation_building.sql
+++ b/ordinary_data/10_installation/0_od_installation_building.sql
@@ -17,6 +17,7 @@ ALTER TABLE qwat_od.installation_building ADD COLUMN fk_status       integer not
 ALTER TABLE qwat_od.installation_building ADD COLUMN fk_type         integer not null;
 ALTER TABLE qwat_od.installation_building ADD COLUMN _displayname_en varchar(50) default '';
 ALTER TABLE qwat_od.installation_building ADD COLUMN _displayname_fr varchar(50) default '';
+ALTER TABLE qwat_od.installation_building ADD COLUMN _displayname_ro varchar(50) default '';
 ALTER TABLE qwat_od.installation_building ADD COLUMN schema_visible  boolean not null default true ;
 ALTER TABLE qwat_od.installation_building ADD COLUMN year            smallint    CHECK (year IS NULL OR year > 1800 AND year < 2100);
 ALTER TABLE qwat_od.installation_building ADD COLUMN parcel          varchar(30) default '';
@@ -42,6 +43,7 @@ $BODY$
 BEGIN
 	 NEW._displayname_en = installation_type.short_en||' '||NEW.name FROM qwat_vl.installation_type WHERE NEW.fk_type = installation_type.id;
 	 NEW._displayname_fr = installation_type.short_fr||' '||NEW.name FROM qwat_vl.installation_type WHERE NEW.fk_type = installation_type.id;
+         NEW._displayname_ro = installation_type.short_ro||' '||NEW.name FROM qwat_vl.installation_type WHERE NEW.fk_type = installation_type.id;
 	 RETURN NEW;
 END;
 $BODY$

--- a/ordinary_data/10_installation/od_installation_valvechamber.sql
+++ b/ordinary_data/10_installation/od_installation_valvechamber.sql
@@ -35,8 +35,12 @@ ALTER TABLE qwat_od.installation_valvechamber ADD COLUMN meter              bool
 
 
 /* geometry */
-/*                                 ( table_name,            is_node, create_node, create_schematic, get_pipe, auto_district, auto_pressurezone)*/
+/*point                              ( table_name,           is_node, create_node, create_schematic, get_pipe, auto_district, auto_pressurezone)*/
 SELECT qwat_od.fn_geom_tool_point('installation_valvechamber',true,    true,       true,             false,    true,          false);
+
+/* polygon */
+SELECT AddGeometryColumn('qwat_od', 'installation_valvechamber', 'geometry_polygon', 21781, 'MULTIPOLYGON', 2);
+CREATE INDEX installation_valvechamber_poly_geoidx ON qwat_od.installation_valvechamber USING GIST ( geometry_polygon );
 
 /* Constraints */
 ALTER TABLE qwat_od.installation_valvechamber ADD CONSTRAINT installation_valvechamber_fk_installation FOREIGN KEY (fk_installation) REFERENCES qwat_od.installation_building(id) MATCH FULL; CREATE INDEX fki_installation_valvechamber_fk_installation ON qwat_od.installation_valvechamber(fk_installation);
@@ -59,3 +63,17 @@ SELECT
 	INNER JOIN      qwat_od.distributor     ON distributor.id     = installation_valvechamber.fk_distributor
 	LEFT OUTER JOIN qwat_vl.remote_type     ON remote_type.id     = installation_valvechamber.fk_remote
 	INNER JOIN      qwat_vl.watertype       ON watertype.id       = installation_valvechamber.fk_watertype;
+
+CREATE OR REPLACE VIEW qwat_od.vw_installation_valvechamber_ro AS
+SELECT
+        installation_valvechamber.*,
+        status.value_ro AS status,
+        status.active AS active,
+        distributor.name AS distributor,
+        remote_type.value_ro AS remote,
+        watertype.value_ro AS watertype
+        FROM qwat_od.installation_valvechamber
+        INNER JOIN      qwat_vl.status          ON status.id          = installation_valvechamber.fk_status
+        INNER JOIN      qwat_od.distributor     ON distributor.id     = installation_valvechamber.fk_distributor
+        LEFT OUTER JOIN qwat_vl.remote_type     ON remote_type.id     = installation_valvechamber.fk_remote
+        INNER JOIN      qwat_vl.watertype       ON watertype.id       = installation_valvechamber.fk_watertype;


### PR DESCRIPTION
- added polygon_geometry for installation_valve chamber

How do you currently present the installation ground projection?
As I want to be able to describe correctly the setup, a polygon geometry would be needed.
The cover should also have the polygon geometry and should be in a parent-children relation with the corresponding installation. What do you think?

The following image depicts an usual valve chamber setup:

![valves](https://cloud.githubusercontent.com/assets/3179646/8302475/4f3d610e-199f-11e5-8556-5506d39b1817.png)
