### PR TITLE
temporary fix on fn_node_set_type so that pipes can be edited

### DIFF
--- a/ordinary_data/nodes/fn_node_set_type.sql
+++ b/ordinary_data/nodes/fn_node_set_type.sql
@@ -28,7 +28,7 @@ $BODY$
 		stmt            text                     ;
 		keep_type       boolean          := false;
 		complement_col  varchar(50)      := ''   ;
-		srid            integer                  ;
+		srid_var        integer                  ;
 	BEGIN
 		/* determine if the node is under an object (hydrant, valve, etc.)
 		   the table node_table contains the names of the tables (i.e. layers) that are typically considered as nodes.
@@ -128,8 +128,8 @@ $BODY$
 			END LOOP;
 			IF keep_type IS FALSE AND grouped.count = 1 THEN
 				/* if the node is only on 1 pipe, check if it intersects another pipe. If yes, hide it */
-				select srid into srid from geometry_columns where f_table_schema = 'qwat_od' and f_table_name = 'node';
-				node_geom := geometry::geometry(Point, srid) FROM qwat_od.node WHERE id = node_id;
+				select srid into srid_var from geometry_columns where f_table_schema = 'qwat_od' and f_table_name = 'node';
+				node_geom := geometry::geometry(POINT,21781) FROM qwat_od.node WHERE id = node_id;
 				/* st_intersects does not work as expected. */
 				intersects := bool_or(ST_DWithin(node_geom, pipe.geometry, 0.0001)) FROM qwat_od.pipe WHERE id != pipe_id;
 				IF intersects IS TRUE THEN


### PR DESCRIPTION
Although the model creation works, the fn_node_set_type didn't work and pipes couldn't be created anymore.
I noticed you had a TODO written and probably you have bigger fixed planned so I didn't try and do a more elegant fix.

Problems:
 PostGIS error while adding features: ERROR:  column reference "srid" is ambiguous 
    LINE 1: select srid           from geometry_columns where f_table_sc...

I changed the srid variable name to srid_var and changed the srid to 21781 in geometry::geometry(Point, srid).

PS. Before you changed the init scripts I was using this command to change the hardcoded values:
find . -type f -print0 | xargs -0 sed -i 's/21781/3844/g'
I didn't mind the hardcoded srid.
