### PR TITLE
fix for new inserts for 3D geometry

### DIFF
--- a/ordinary_data/nodes/od_node.sql
+++ b/ordinary_data/nodes/od_node.sql
@@ -40,9 +40,9 @@ ALTER TABLE qwat_od.node ADD COLUMN _pipe_schema_visible boolean default false;
 ALTER TABLE qwat_od.node ADD CONSTRAINT chk_node_altitude_obj_ref CHECK (fk_object_reference IS NOT NULL OR altitude IS NULL );
 
 /* GEOMETRY */
-ALTER TABLE qwat_od.node ADD COLUMN geometry geometry('POINTZ',:SRID);
-ALTER TABLE qwat_od.node ADD COLUMN geometry_alt1 geometry('POINTZ',:SRID);
-ALTER TABLE qwat_od.node ADD COLUMN geometry_alt2 geometry('POINTZ',:SRID);
+SELECT AddGeometryColumn ('qwat_od','node','geometry',:SRID,'POINT',3, false);
+SELECT AddGeometryColumn ('qwat_od','node','geometry_alt1',:SRID,'POINT',3, false);
+SELECT AddGeometryColumn ('qwat_od','node','geometry_alt2',:SRID,'POINT',3, false);
 CREATE INDEX node_geoidx ON qwat_od.node USING GIST ( geometry );
 CREATE INDEX node_geoidx_alt1 ON qwat_od.node USING GIST ( geometry_alt1 );
 CREATE INDEX node_geoidx_alt2 ON qwat_od.node USING GIST ( geometry_alt2 );

--- a/ordinary_data/pipe/od_pipe_geom.sql
+++ b/ordinary_data/pipe/od_pipe_geom.sql
@@ -15,9 +15,9 @@ ALTER TABLE qwat_od.pipe ADD COLUMN _geometry_alt2_used boolean;
 
 /* ---------------------------- */
 /* -------- ADD GEOM ---------- */
-ALTER TABLE qwat_od.pipe ADD COLUMN geometry      geometry('LINESTRINGZ',:SRID);
-ALTER TABLE qwat_od.pipe ADD COLUMN geometry_alt1 geometry('LINESTRINGZ',:SRID);
-ALTER TABLE qwat_od.pipe ADD COLUMN geometry_alt2 geometry('LINESTRINGZ',:SRID);
+SELECT AddGeometryColumn ('qwat_od','pipe','geometry',:SRID,'LINESTRING',3, false);
+SELECT AddGeometryColumn ('qwat_od','pipe','geometry_alt1',:SRID,'LINESTRING',3, false);
+SELECT AddGeometryColumn ('qwat_od','pipe','geometry_alt2',:SRID,'LINESTRING',3, false);
 
 CREATE INDEX pipe_geoidx      ON qwat_od.pipe USING GIST ( geometry );
 CREATE INDEX pipe_geoidx_alt1 ON qwat_od.pipe USING GIST ( geometry_alt1 );

--- a/ordinary_data/surveypoint/od_surveypoint.sql
+++ b/ordinary_data/surveypoint/od_surveypoint.sql
@@ -17,7 +17,7 @@ ALTER TABLE qwat_od.surveypoint ADD COLUMN description      text;
 ALTER TABLE qwat_od.surveypoint ADD COLUMN date             date;
 ALTER TABLE qwat_od.surveypoint ADD COLUMN fk_folder        integer ;
 ALTER TABLE qwat_od.surveypoint ADD COLUMN altitude         decimal(10,3) default null;
-ALTER TABLE qwat_od.surveypoint ADD COLUMN geometry         geometry(POINTZ,:SRID);
+SELECT AddGeometryColumn ('qwat_od','surveypoint','geometry',:SRID,'POINT',3, false);
 -- TODO add fk_object_reference
 
 /* constraints */


### PR DESCRIPTION
The triggers that make the 2d to 3d translation don't get to run
due to typemod constraints that are run before the geometry is fixed.
This enables the old behaviour of storing geometry with check constraints.

Followup https://github.com/qwat/qwat-data-model/commit/78e9dd183fae78ec39dbf86a404aad5d727a5e66