### PR TITLE
geometry NOT NULL constraint for pipes, cover, node, crossings

### DIFF
--- a/ordinary_data/installation/od_cover.sql
+++ b/ordinary_data/installation/od_cover.sql
@@ -20,7 +20,7 @@ ALTER TABLE qwat_od.cover ADD COLUMN altitude        numeric(8,3);
 ALTER TABLE qwat_od.cover ADD COLUMN circular        boolean default true;
 ALTER TABLE qwat_od.cover ADD COLUMN form_dimension  decimal(10,3)       ; COMMENT ON COLUMN qwat_od.cover.form_dimension  IS 'depending on the cover form, it represents either the diameter of circle or the length of a square side';
 ALTER TABLE qwat_od.cover ADD COLUMN remark          text                ;
-ALTER TABLE qwat_od.cover ADD COLUMN geometry         geometry('PointZ', :SRID);
+ALTER TABLE qwat_od.cover ADD COLUMN geometry         geometry('PointZ', :SRID) NOT NULL;
 ALTER TABLE qwat_od.cover ADD COLUMN geometry_polygon geometry('Polygon', :SRID);
 
 

--- a/ordinary_data/nodes/od_node.sql
+++ b/ordinary_data/nodes/od_node.sql
@@ -34,7 +34,7 @@ ALTER TABLE qwat_od.node ADD COLUMN _pipe_orientation    float   default 0;
 ALTER TABLE qwat_od.node ADD COLUMN _pipe_schema_visible boolean default false;
 
 /* GEOMETRY */
-ALTER TABLE qwat_od.node ADD COLUMN geometry geometry('POINTZ',:SRID);
+ALTER TABLE qwat_od.node ADD COLUMN geometry geometry('POINTZ',:SRID) NOT NULL;
 ALTER TABLE qwat_od.node ADD COLUMN geometry_alt1 geometry('POINTZ',:SRID);
 ALTER TABLE qwat_od.node ADD COLUMN geometry_alt2 geometry('POINTZ',:SRID);
 ALTER TABLE qwat_od.node ADD COLUMN update_geometry_alt1 boolean default null; -- used to determine if alternative geometries should be updated when main geometry is updated

--- a/ordinary_data/pipe/od_crossing.sql
+++ b/ordinary_data/pipe/od_crossing.sql
@@ -20,7 +20,7 @@ WITH (
   OIDS=FALSE
 );
 
-ALTER TABLE qwat_od.crossing ADD COLUMN geometry geometry('POINT',:SRID);
+ALTER TABLE qwat_od.crossing ADD COLUMN geometry geometry('POINT',:SRID) NOT NULL;
 
 CREATE OR REPLACE FUNCTION qwat_od.ft_controled_crossing()
 RETURNS trigger AS

--- a/ordinary_data/pipe/od_pipe_geom.sql
+++ b/ordinary_data/pipe/od_pipe_geom.sql
@@ -17,7 +17,7 @@ ALTER TABLE qwat_od.pipe ADD COLUMN update_geometry_alt2 boolean default null; -
 
 /* ---------------------------- */
 /* -------- ADD GEOM ---------- */
-ALTER TABLE qwat_od.pipe ADD COLUMN geometry      geometry('LINESTRINGZ',:SRID);
+ALTER TABLE qwat_od.pipe ADD COLUMN geometry      geometry('LINESTRINGZ',:SRID) NOT NULL;
 ALTER TABLE qwat_od.pipe ADD COLUMN geometry_alt1 geometry('LINESTRINGZ',:SRID);
 ALTER TABLE qwat_od.pipe ADD COLUMN geometry_alt2 geometry('LINESTRINGZ',:SRID);
 


### PR DESCRIPTION
Other possible tables that can have NOT NULL but I wasn't sure if there's any usage of these geometry-less wise:
- leak
- printmap
- pressurezone
- protectionzone
- remote
- subscriber_reference

If you think these should always have geometry then I can make the changes and rebase.