### PR TITLE
add unique constraint on pipe geometry

### DIFF
--- a/ordinary_data/pipe/od_pipe_geom.sql
+++ b/ordinary_data/pipe/od_pipe_geom.sql
@@ -16,7 +16,7 @@ ALTER TABLE qwat_od.pipe ADD COLUMN update_geometry_alt2 boolean default null; -
 
 /* ---------------------------- */
 /* -------- ADD GEOM ---------- */
-ALTER TABLE qwat_od.pipe ADD COLUMN geometry      geometry('LINESTRINGZ',:SRID) NOT NULL;
+ALTER TABLE qwat_od.pipe ADD COLUMN geometry      geometry('LINESTRINGZ',:SRID) UNIQUE NOT NULL;
 ALTER TABLE qwat_od.pipe ADD COLUMN geometry_alt1 geometry('LINESTRINGZ',:SRID);
 ALTER TABLE qwat_od.pipe ADD COLUMN geometry_alt2 geometry('LINESTRINGZ',:SRID);
 


### PR DESCRIPTION
As I just found some duplicate geometries in the pipe data that I work with I'm enforcing a unique constraint on the geometry column.
I think this should also be here (upstream for me).
@3nids & others: How does this sound to you?