### PR TITLE
pipe year columns <= current year + column comments

### DIFF
--- a/ordinary_data/pipe/od_pipe.sql
+++ b/ordinary_data/pipe/od_pipe.sql
@@ -53,8 +53,10 @@ ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_fk_protection     FOREIGN KEY (fk_p
 ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_fk_status         FOREIGN KEY (fk_status)         REFERENCES qwat_vl.status(id)             MATCH FULL; CREATE INDEX fki_pipe_fk_status        ON qwat_od.pipe(fk_status);
 ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_fk_watertype      FOREIGN KEY (fk_watertype)      REFERENCES qwat_vl.watertype(id)          MATCH FULL; CREATE INDEX fki_pipe_fk_watertype     ON qwat_od.pipe(fk_watertype);
 ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_fk_folder         FOREIGN KEY (fk_folder)         REFERENCES qwat_od.folder(id)             MATCH FULL; CREATE INDEX fki_pipe_fk_folder        ON qwat_od.pipe(fk_folder);
-ALTER TABLE qwat_od.pipe ADD CONSTRAINT ck_pipe_year CHECK (year IS NULL OR year > 1800 AND year <= EXTRACT(YEAR FROM NOW()));
-COMMENT ON CONSTRAINT ck_pipe_year ON qwat_od.pipe IS 'Year when the pipe was installed should be between 1800 and the current year or unknown.';
+ALTER TABLE qwat_od.pipe ADD CONSTRAINT ck_pipe_year CHECK
+(year IS NULL OR year > 1800 AND year <= EXTRACT(YEAR FROM NOW()) OR 
+(fk_status = 1306 AND (year IS NULL OR year >=  EXTRACT(YEAR FROM NOW()) AND year < 2100)));
+COMMENT ON CONSTRAINT ck_pipe_year ON qwat_od.pipe IS 'Year when the pipe was installed should be between 1800 and the current year or unknown. If the pipe is in a project then the year column shows when the pipe is to be installed which is between the current year and 2100';
 ALTER TABLE qwat_od.pipe ADD CONSTRAINT ck_pipe_year_rehabilitation CHECK (year_rehabilitation IS NULL OR year_rehabilitation > 1800 AND year_rehabilitation <= EXTRACT(YEAR FROM NOW()));
 COMMENT ON CONSTRAINT ck_pipe_year_rehabilitation ON qwat_od.pipe IS 'Pipe rehabilitation year should be between 1800 and the current year or unknown.';
 ALTER TABLE qwat_od.pipe ADD CONSTRAINT ck_pipe_year_end CHECK (year_end IS NULL OR year_end > 1800 AND year_end <= EXTRACT(YEAR FROM NOW()));

--- a/ordinary_data/pipe/od_pipe.sql
+++ b/ordinary_data/pipe/od_pipe.sql
@@ -22,14 +22,18 @@ ALTER TABLE qwat_od.pipe ADD COLUMN fk_status        integer not null;
 ALTER TABLE qwat_od.pipe ADD COLUMN fk_watertype     integer not null;
 ALTER TABLE qwat_od.pipe ADD COLUMN fk_locationtype  integer[];
 ALTER TABLE qwat_od.pipe ADD COLUMN fk_folder        integer ;
-ALTER TABLE qwat_od.pipe ADD COLUMN year             smallint CHECK (year IS NULL OR year > 1800 AND year < 2100);
-ALTER TABLE qwat_od.pipe ADD COLUMN year_rehabilitation smallint CHECK (year_rehabilitation IS NULL OR year_rehabilitation > 1800 AND year_rehabilitation < 2100);
-ALTER TABLE qwat_od.pipe ADD COLUMN year_end         smallint CHECK (year_end IS NULL OR year_end > 1800 AND year_end < 2100);
+ALTER TABLE qwat_od.pipe ADD COLUMN year             smallint;
+ALTER TABLE qwat_od.pipe ADD COLUMN year_rehabilitation smallint;
+ALTER TABLE qwat_od.pipe ADD COLUMN year_end         smallint;
 ALTER TABLE qwat_od.pipe ADD COLUMN tunnel_or_bridge boolean default false;
 ALTER TABLE qwat_od.pipe ADD COLUMN pressure_nominal smallint default 16;
 ALTER TABLE qwat_od.pipe ADD COLUMN remark           text         ;
 ALTER TABLE qwat_od.pipe ADD COLUMN _valve_count     smallint default NULL;
 ALTER TABLE qwat_od.pipe ADD COLUMN _valve_closed    boolean default NULL;
+
+COMMENT ON COLUMN qwat_od.pipe.year IS 'Represents the year when the pipe was installed.';
+COMMENT ON COLUMN qwat_od.pipe.year_rehabilitation IS 'Represents the year when the pipe was rehabilitated.';
+COMMENT ON COLUMN qwat_od.pipe.year_end IS 'Represents the year when the pipe was shut down.';
 
 /* schema view */
 DO $$ BEGIN PERFORM qwat_sys.fn_enable_schemavisible( 'pipe', 'pipe_function', 'fk_function' ); END $$;
@@ -49,6 +53,12 @@ ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_fk_protection     FOREIGN KEY (fk_p
 ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_fk_status         FOREIGN KEY (fk_status)         REFERENCES qwat_vl.status(id)             MATCH FULL; CREATE INDEX fki_pipe_fk_status        ON qwat_od.pipe(fk_status);
 ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_fk_watertype      FOREIGN KEY (fk_watertype)      REFERENCES qwat_vl.watertype(id)          MATCH FULL; CREATE INDEX fki_pipe_fk_watertype     ON qwat_od.pipe(fk_watertype);
 ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_fk_folder         FOREIGN KEY (fk_folder)         REFERENCES qwat_od.folder(id)             MATCH FULL; CREATE INDEX fki_pipe_fk_folder        ON qwat_od.pipe(fk_folder);
+ALTER TABLE qwat_od.pipe ADD CONSTRAINT ck_pipe_year CHECK (year IS NULL OR year > 1800 AND year <= EXTRACT(YEAR FROM NOW()));
+COMMENT ON CONSTRAINT ck_pipe_year ON qwat_od.pipe IS 'Year when the pipe was installed should be between 1800 and the current year or unknown.';
+ALTER TABLE qwat_od.pipe ADD CONSTRAINT ck_pipe_year_rehabilitation CHECK (year_rehabilitation IS NULL OR year_rehabilitation > 1800 AND year_rehabilitation <= EXTRACT(YEAR FROM NOW()));
+COMMENT ON CONSTRAINT ck_pipe_year_rehabilitation ON qwat_od.pipe IS 'Pipe rehabilitation year should be between 1800 and the current year or unknown.';
+ALTER TABLE qwat_od.pipe ADD CONSTRAINT ck_pipe_year_end CHECK (year_end IS NULL OR year_end > 1800 AND year_end <= EXTRACT(YEAR FROM NOW()));
+COMMENT ON CONSTRAINT ck_pipe_year_end ON qwat_od.pipe IS 'Year when the pipe was shut down should be between 1800 and the current year or unknown';
 
 /*----------------!!!---!!!----------------*/
 /* Trigger for tunnel_or_bridge */

--- a/ordinary_data/pipe/od_pipe.sql
+++ b/ordinary_data/pipe/od_pipe.sql
@@ -54,14 +54,14 @@ ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_fk_status         FOREIGN KEY (fk_s
 ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_fk_watertype      FOREIGN KEY (fk_watertype)      REFERENCES qwat_vl.watertype(id)          MATCH FULL; CREATE INDEX fki_pipe_fk_watertype     ON qwat_od.pipe(fk_watertype);
 ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_fk_folder         FOREIGN KEY (fk_folder)         REFERENCES qwat_od.folder(id)             MATCH FULL; CREATE INDEX fki_pipe_fk_folder        ON qwat_od.pipe(fk_folder);
 
-ALTER TABLE qwat_od.pipe ADD CONSTRAINT ck_pipe_year CHECK (year IS NULL OR year > 1800 AND (year <= EXTRACT(YEAR FROM NOW()) OR fk_status = 1306 AND year - 50 <= EXTRACT(YEAR FROM NOW())));
-COMMENT ON CONSTRAINT ck_pipe_year ON qwat_od.pipe IS 'Year when the pipe was installed should be either NULL - not filled OR between 1800 and the current year; if the pipe has the project status (fk_status = 1306) then the year can be between 1800 and 50 years from now';
+ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_year_check CHECK (year IS NULL OR year > 1800 AND (year <= EXTRACT(YEAR FROM NOW()) OR fk_status = 1306 AND year - 50 <= EXTRACT(YEAR FROM NOW())));
+COMMENT ON CONSTRAINT pipe_year_check ON qwat_od.pipe IS 'Year when the pipe was installed should be either NULL - not filled OR between 1800 and the current year; if the pipe has the project status (fk_status = 1306) then the year can be between 1800 and 50 years from now';
 
-ALTER TABLE qwat_od.pipe ADD CONSTRAINT ck_pipe_year_rehabilitation CHECK (year_rehabilitation IS NULL OR year_rehabilitation > 1800 AND year_rehabilitation <= EXTRACT(YEAR FROM NOW()));
-COMMENT ON CONSTRAINT ck_pipe_year_rehabilitation ON qwat_od.pipe IS 'Pipe rehabilitation year should be between 1800 and the current year or NULL/not filled';
+ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_year_rehabilitation_check CHECK (year_rehabilitation IS NULL OR year_rehabilitation > 1800 AND year_rehabilitation <= EXTRACT(YEAR FROM NOW()));
+COMMENT ON CONSTRAINT pipe_year_rehabilitation_check ON qwat_od.pipe IS 'Pipe rehabilitation year should be between 1800 and the current year or NULL/not filled';
 
-ALTER TABLE qwat_od.pipe ADD CONSTRAINT ck_pipe_year_end CHECK (year_end IS NULL OR year_end > 1800 AND year_end <= EXTRACT(YEAR FROM NOW()));
-COMMENT ON CONSTRAINT ck_pipe_year_end ON qwat_od.pipe IS 'Year when the pipe was shut down should be between 1800 and the current year or NULL/not filled';
+ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_year_end_check CHECK (year_end IS NULL OR year_end > 1800 AND year_end <= EXTRACT(YEAR FROM NOW()));
+COMMENT ON CONSTRAINT pipe_year_end_check ON qwat_od.pipe IS 'Year when the pipe was shut down should be between 1800 and the current year or NULL/not filled';
 
 /*----------------!!!---!!!----------------*/
 /* Trigger for tunnel_or_bridge */

--- a/ordinary_data/pipe/od_pipe.sql
+++ b/ordinary_data/pipe/od_pipe.sql
@@ -31,9 +31,9 @@ ALTER TABLE qwat_od.pipe ADD COLUMN remark           text         ;
 ALTER TABLE qwat_od.pipe ADD COLUMN _valve_count     smallint default NULL;
 ALTER TABLE qwat_od.pipe ADD COLUMN _valve_closed    boolean default NULL;
 
-COMMENT ON COLUMN qwat_od.pipe.year IS 'Represents the year when the pipe was installed.';
-COMMENT ON COLUMN qwat_od.pipe.year_rehabilitation IS 'Represents the year when the pipe was rehabilitated.';
-COMMENT ON COLUMN qwat_od.pipe.year_end IS 'Represents the year when the pipe was shut down.';
+COMMENT ON COLUMN qwat_od.pipe.year IS 'Represents the year when the pipe was installed. It can be NULL (not filled), between 1800 and the current year. If the pipe has project status then the maximum value of the year can be 50 years from the current year.';
+COMMENT ON COLUMN qwat_od.pipe.year_rehabilitation IS 'Represents the year when the pipe was rehabilitated. It can be NULL (not filled) or between 1800 and the current year.';
+COMMENT ON COLUMN qwat_od.pipe.year_end IS 'Represents the year when the pipe was shut down. It can be NULL (not filled) or between 1800 and the current year.';
 
 /* schema view */
 DO $$ BEGIN PERFORM qwat_sys.fn_enable_schemavisible( 'pipe', 'pipe_function', 'fk_function' ); END $$;
@@ -53,14 +53,15 @@ ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_fk_protection     FOREIGN KEY (fk_p
 ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_fk_status         FOREIGN KEY (fk_status)         REFERENCES qwat_vl.status(id)             MATCH FULL; CREATE INDEX fki_pipe_fk_status        ON qwat_od.pipe(fk_status);
 ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_fk_watertype      FOREIGN KEY (fk_watertype)      REFERENCES qwat_vl.watertype(id)          MATCH FULL; CREATE INDEX fki_pipe_fk_watertype     ON qwat_od.pipe(fk_watertype);
 ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_fk_folder         FOREIGN KEY (fk_folder)         REFERENCES qwat_od.folder(id)             MATCH FULL; CREATE INDEX fki_pipe_fk_folder        ON qwat_od.pipe(fk_folder);
-ALTER TABLE qwat_od.pipe ADD CONSTRAINT ck_pipe_year CHECK
-(year IS NULL OR year > 1800 AND year <= EXTRACT(YEAR FROM NOW()) OR 
-(fk_status = 1306 AND (year IS NULL OR year >=  EXTRACT(YEAR FROM NOW()) AND year < 2100)));
-COMMENT ON CONSTRAINT ck_pipe_year ON qwat_od.pipe IS 'Year when the pipe was installed should be between 1800 and the current year or unknown. If the pipe is in a project then the year column shows when the pipe is to be installed which is between the current year and 2100';
+
+ALTER TABLE qwat_od.pipe ADD CONSTRAINT ck_pipe_year CHECK (year IS NULL OR year > 1800 AND (year <= EXTRACT(YEAR FROM NOW()) OR fk_status = 1306 AND year - 50 <= EXTRACT(YEAR FROM NOW())));
+COMMENT ON CONSTRAINT ck_pipe_year ON qwat_od.pipe IS 'Year when the pipe was installed should be either NULL - not filled OR between 1800 and the current year; if the pipe has the project status (fk_status = 1306) then the year can be between 1800 and 50 years from now';
+
 ALTER TABLE qwat_od.pipe ADD CONSTRAINT ck_pipe_year_rehabilitation CHECK (year_rehabilitation IS NULL OR year_rehabilitation > 1800 AND year_rehabilitation <= EXTRACT(YEAR FROM NOW()));
-COMMENT ON CONSTRAINT ck_pipe_year_rehabilitation ON qwat_od.pipe IS 'Pipe rehabilitation year should be between 1800 and the current year or unknown.';
+COMMENT ON CONSTRAINT ck_pipe_year_rehabilitation ON qwat_od.pipe IS 'Pipe rehabilitation year should be between 1800 and the current year or NULL/not filled';
+
 ALTER TABLE qwat_od.pipe ADD CONSTRAINT ck_pipe_year_end CHECK (year_end IS NULL OR year_end > 1800 AND year_end <= EXTRACT(YEAR FROM NOW()));
-COMMENT ON CONSTRAINT ck_pipe_year_end ON qwat_od.pipe IS 'Year when the pipe was shut down should be between 1800 and the current year or unknown';
+COMMENT ON CONSTRAINT ck_pipe_year_end ON qwat_od.pipe IS 'Year when the pipe was shut down should be between 1800 and the current year or NULL/not filled';
 
 /*----------------!!!---!!!----------------*/
 /* Trigger for tunnel_or_bridge */

--- a/update/delta/delta_1.3.3_011_reworked_pipe_year_constraints_and_comments.sql
+++ b/update/delta/delta_1.3.3_011_reworked_pipe_year_constraints_and_comments.sql
@@ -1,0 +1,17 @@
+ALTER TABLE qwat_od.pipe DROP CONSTRAINT pipe_year_check;
+ALTER TABLE qwat_od.pipe DROP CONSTRAINT pipe_year_end_check;
+ALTER TABLE qwat_od.pipe DROP CONSTRAINT pipe_year_rehabilitation_check;
+
+ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_year_check CHECK (year IS NULL OR year > 1800 AND (year <= EXTRACT(YEAR FROM NOW()) OR fk_status = 1306 AND year - 50 <= EXTRACT(YEAR FROM NOW())));
+COMMENT ON CONSTRAINT pipe_year_check ON qwat_od.pipe IS 'Year when the pipe was installed should be either NULL - not filled OR between 1800 and the current year; if the pipe has the project status (fk_status = 1306) then the year can be between 1800 and 50 years from now';
+
+ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_year_rehabilitation_check CHECK (year_rehabilitation IS NULL OR year_rehabilitation > 1800 AND year_rehabilitation <= EXTRACT(YEAR FROM NOW()));
+COMMENT ON CONSTRAINT pipe_year_rehabilitation_check ON qwat_od.pipe IS 'Pipe rehabilitation year should be between 1800 and the current year or NULL/not filled';
+
+ALTER TABLE qwat_od.pipe ADD CONSTRAINT pipe_year_end_check CHECK (year_end IS NULL OR year_end > 1800 AND year_end <= EXTRACT(YEAR FROM NOW()));
+COMMENT ON CONSTRAINT pipe_year_end_check ON qwat_od.pipe IS 'Year when the pipe was shut down should be between 1800 and the current year or NULL/not fill';
+
+COMMENT ON COLUMN qwat_od.pipe.year IS 'Represents the year when the pipe was installed. It can be NULL (not filled), between 1800 and the current year. If the pipe has project status then the maximum value of the year can be 50 years from the current year.';
+COMMENT ON COLUMN qwat_od.pipe.year_rehabilitation IS 'Represents the year when the pipe was rehabilitated. It can be NULL (not filled) or between 1800 and the current year.';
+COMMENT ON COLUMN qwat_od.pipe.year_end IS 'Represents the year when the pipe was shut down. It can be NULL (not filled) or between 1800 and the current year.';
+


### PR DESCRIPTION
Reworked constraints on year, year_rehabilitation and year_end columns
constraints so that the values are smaller that the current year.
I also added comments on the constraints and on the columns.

Is there any reason that the year would be bigger than the current_year and smaller than 2100.

I am thinking about having a convention so that pipes that are in a project (with `fk_status` 1306 - which means they are in a project) could have a `year` value that is bigger than the current year and that it should represent the year when the pipe should be installed. I don't know yet if this would serve anyone, but I just thought of bringing it out as a possibility.

I am unsure of my English when describing the year_end column **.. year when the pipe was shut down**. Maybe someone can suggest a better expression than **shut down**.

Thoughts?


<!---
@huboard:{"order":116.15089051318427,"milestone_order":128,"custom_state":""}
-->
