### PR TITLE
add hardcoded _schema_visible field to pipes and valves for enhanced …

### DIFF
--- a/ordinary_data/nodes/od_network_element.sql
+++ b/ordinary_data/nodes/od_network_element.sql
@@ -27,9 +27,6 @@ ALTER TABLE qwat_od.network_element ADD COLUMN year_end            smallint CHEC
 ALTER TABLE qwat_od.network_element ADD COLUMN orientation         float default null; COMMENT ON COLUMN qwat_od.network_element.orientation IS 'orientation field aims at overwrtiting qwat_od.node._pipe_orientation which is automatically calculated from the pipes. In the editable views, orientation will be COALESCE(netwrok_element.orientation, node._pipe_orientation). Update will be forwarded to network_element.';
 ALTER TABLE qwat_od.network_element ADD COLUMN remark              text;
 
-/* SCHEMA VIEW */
-DO $$ BEGIN PERFORM qwat_sys.fn_enable_schemaview('network_element'); END $$;
-
 /* LABELS */
 DO $$ BEGIN PERFORM qwat_sys.fn_label_create_fields('network_element'); END $$;
 

--- a/ordinary_data/pipe/od_pipe.sql
+++ b/ordinary_data/pipe/od_pipe.sql
@@ -32,7 +32,7 @@ ALTER TABLE qwat_od.pipe ADD COLUMN _valve_count     smallint default NULL;
 ALTER TABLE qwat_od.pipe ADD COLUMN _valve_closed    boolean default NULL;
 
 /* schema view */
-DO $$ BEGIN PERFORM qwat_sys.fn_enable_schemaview( 'pipe' ); END $$;
+DO $$ BEGIN PERFORM qwat_sys.fn_enable_schemavisible( 'pipe', 'pipe_function', 'fk_function' ); END $$;
 
 /* LABELS */
 DO $$ BEGIN PERFORM qwat_sys.fn_label_create_fields('pipe', false, false); END $$;

--- a/ordinary_data/valve/od_valve.sql
+++ b/ordinary_data/valve/od_valve.sql
@@ -78,7 +78,7 @@ ALTER TABLE qwat_od.valve ADD COLUMN update_geometry_alt2 boolean default null; 
 
 
 /* Schema view */
-DO $$ BEGIN PERFORM qwat_sys.fn_enable_schemaview('valve'); END $$;
+DO $$ BEGIN PERFORM qwat_sys.fn_enable_schemavisible('valve', 'valve_function', 'fk_valve_function'); END $$;
 
 /* LABELS */
 DO $$ BEGIN PERFORM qwat_sys.fn_label_create_fields('valve'); END $$;
@@ -222,4 +222,3 @@ CREATE TRIGGER tr_valve_add_pipe_vertex_update
   WHEN (ST_Equals(ST_Force2d(NEW.geometry), ST_Force2d(OLD.geometry)) IS FALSE )
   EXECUTE PROCEDURE qwat_od.ft_valve_add_pipe_vertex();
 COMMENT ON TRIGGER tr_valve_add_pipe_vertex_update ON qwat_od.valve IS 'Trigger: updates auto fields after geom update.';
-

--- a/system/versions_insert.sql
+++ b/system/versions_insert.sql
@@ -2,4 +2,4 @@
 
 
 
-INSERT INTO qwat_sys.versions (module, version) values ('model.core','1.2.7');
+INSERT INTO qwat_sys.versions (module, version) values ('model.core','1.2.8');

--- a/update/delta/delta_1.2.8_schema_visible_perf.sql
+++ b/update/delta/delta_1.2.8_schema_visible_perf.sql
@@ -1,9 +1,26 @@
 /*
-	qWat - QGIS Water Module
+This creates a field _schema_visible which determines if
+an element is visible in schematic view.
+It is calculated by COALESCE(schema_force_visible, value_list.schema_visible).
+This allows direct use of this field in QGIS for rule-based labeling and
+fixes performance issues if calculation is done on client side.
 
-	SQL file :: function to add schema view capability to tables
+* schema_visible field is dropped on network_element as it is not used (was introduced for valves at the origin)
+* _schema_visible and schema_force_visible are added to pipe and valve tables by the qwat_sys.fn_enable_schemavisible function
+* old function qwat_sys.fn_enable_schemaview is enhanced and renamed
 */
+BEGIN;
 
+ALTER TABLE qwat_od.network_element DROP COLUMN schema_force_visible;
+
+DROP FUNCTION qwat_sys.fn_enable_schemaview(text);
+
+ALTER TABLE qwat_od.pipe RENAME COLUMN schema_force_visible TO schema_force_visible_old;
+ALTER TABLE qwat_od.pipe DROP CONSTRAINT pipe_schema_force_visible;
+DROP INDEX qwat_od.fki_pipe_schema_force_visible;
+ALTER TABLE qwat_od.valve RENAME COLUMN schema_force_visible TO schema_force_visible_old;
+ALTER TABLE qwat_od.valve DROP CONSTRAINT valve_schema_force_visible;
+DROP INDEX qwat_od.fki_valve_schema_force_visible;
 
 CREATE OR REPLACE FUNCTION qwat_sys.fn_enable_schemavisible(_table_name text, _vl_table text, _fk_field text)
 	RETURNS VOID AS
@@ -58,3 +75,16 @@ END;
 $BODY$
 LANGUAGE plpgsql;
 COMMENT ON FUNCTION qwat_sys.fn_enable_schemavisible(text,text,text) IS 'Add a column schema_force_visible used to overwrite the schema_view defined by the auxiliary table (pipe_function for instance). Add a column _schema_visible which determines if the element is visible in the schema (updated by trigger).';
+
+
+DO $$ BEGIN PERFORM qwat_sys.fn_enable_schemavisible('valve', 'valve_function', 'fk_valve_function'); END $$;
+DO $$ BEGIN PERFORM qwat_sys.fn_enable_schemavisible('pipe', 'pipe_function', 'fk_function'); END $$;
+
+UPDATE qwat_od.pipe SET schema_force_visible = schema_force_visible_old;
+UPDATE qwat_od.valve SET schema_force_visible = schema_force_visible_old;
+
+ALTER TABLE qwat_od.pipe DROP COLUMN schema_force_visible_old;
+ALTER TABLE qwat_od.valve DROP COLUMN schema_force_visible_old;
+
+
+COMMIT;

--- a/update/delta/delta_1.2.8_schema_visible_perf.sql
+++ b/update/delta/delta_1.2.8_schema_visible_perf.sql
@@ -57,15 +57,15 @@ $BODY$
 				_vl_table,
 				_fk_field);
 
-		EXECUTE format('CREATE TRIGGER tr_%1$I_schema_view_update
-						BEFORE UPDATE OF %2$I
+		EXECUTE format('CREATE TRIGGER tr_%1$I_schema_visible_update
+						BEFORE UPDATE OF schema_force_visible, %2$I
 						ON qwat_od.%1$I
 						FOR EACH ROW
   					EXECUTE PROCEDURE qwat_od.ft_%1$I_schema_visible();',
 				_table_name,
 				_fk_field);
 
-		EXECUTE format('CREATE TRIGGER tr_%1$I_schema_view_insert
+		EXECUTE format('CREATE TRIGGER tr_%1$I_schema_visible_insert
 						BEFORE INSERT
 						ON qwat_od.%1$I
 						FOR EACH ROW
@@ -80,8 +80,11 @@ COMMENT ON FUNCTION qwat_sys.fn_enable_schemavisible(text,text,text) IS 'Add a c
 DO $$ BEGIN PERFORM qwat_sys.fn_enable_schemavisible('valve', 'valve_function', 'fk_valve_function'); END $$;
 DO $$ BEGIN PERFORM qwat_sys.fn_enable_schemavisible('pipe', 'pipe_function', 'fk_function'); END $$;
 
-UPDATE qwat_od.pipe SET schema_force_visible = schema_force_visible_old;
-UPDATE qwat_od.valve SET schema_force_visible = schema_force_visible_old;
+UPDATE qwat_od.pipe SET schema_force_visible = schema_force_visible_old where schema_force_visible_old is not null;
+UPDATE qwat_od.valve SET schema_force_visible = schema_force_visible_old where schema_force_visible_old is not null;
+
+UPDATE qwat_od.pipe SET _schema_visible = schema_visible FROM qwat_vl.pipe_function where pipe_function.id = fk_function AND schema_force_visible is NULL;
+UPDATE qwat_od.valve SET _schema_visible = schema_visible FROM qwat_vl.valve_function where valve_function.id = fk_valve_function AND schema_force_visible is NULL;
 
 ALTER TABLE qwat_od.pipe DROP COLUMN schema_force_visible_old;
 ALTER TABLE qwat_od.valve DROP COLUMN schema_force_visible_old;

--- a/update/delta/delta_1.2.8_schema_visible_perf.sql
+++ b/update/delta/delta_1.2.8_schema_visible_perf.sql
@@ -8,6 +8,7 @@ fixes performance issues if calculation is done on client side.
 * schema_visible field is dropped on network_element as it is not used (was introduced for valves at the origin)
 * _schema_visible and schema_force_visible are added to pipe and valve tables by the qwat_sys.fn_enable_schemavisible function
 * old function qwat_sys.fn_enable_schemaview is enhanced and renamed
+* see https://github.com/qwat/qwat-data-model/pull/194
 */
 BEGIN;
 
@@ -88,6 +89,10 @@ UPDATE qwat_od.valve SET _schema_visible = schema_visible FROM qwat_vl.valve_fun
 
 ALTER TABLE qwat_od.pipe DROP COLUMN schema_force_visible_old;
 ALTER TABLE qwat_od.valve DROP COLUMN schema_force_visible_old;
+
+-- also add automatic valve actuation to fit automatic air release valve
+-- see https://github.com/qwat/qwat-data-model/pull/191
+INSERT INTO qwat_vl.valve_actuation (id, value_en, value_fr, value_ro ) VALUES (6405, 'automatic', 'automatique', 'automată');
 
 UPDATE qwat_sys.versions SET version = '1.2.8';
 

--- a/update/delta/delta_1.2.8_schema_visible_perf.sql
+++ b/update/delta/delta_1.2.8_schema_visible_perf.sql
@@ -86,5 +86,6 @@ UPDATE qwat_od.valve SET schema_force_visible = schema_force_visible_old;
 ALTER TABLE qwat_od.pipe DROP COLUMN schema_force_visible_old;
 ALTER TABLE qwat_od.valve DROP COLUMN schema_force_visible_old;
 
+UPDATE qwat_sys.versions SET version = '1.2.8';
 
 COMMIT;

--- a/value_lists/vl_valve_actuation.sql
+++ b/value_lists/vl_valve_actuation.sql
@@ -22,6 +22,7 @@ INSERT INTO qwat_vl.valve_actuation (id, value_en, value_fr, value_ro )         
 INSERT INTO qwat_vl.valve_actuation (id, value_en, value_fr, value_ro )         VALUES (6402, 'left hand control', 'manuel à gauche', 'manuală la stânga');
 INSERT INTO qwat_vl.valve_actuation (id, value_en, value_fr, value_ro )       	VALUES (6403, 'electric drive', 'électrique', 'electrică');
 INSERT INTO qwat_vl.valve_actuation (id, value_en, value_fr, value_ro )       	VALUES (6404, 'remote controlled', 'télécommandée', 'telecomandată');
+INSERT INTO qwat_vl.valve_actuation (id, value_en, value_fr, value_ro )         VALUES (6405, 'automatic', 'automatique', 'automată');
 
 
 


### PR DESCRIPTION
…perfomance on QGIS

This creates a field _schema_visible which determines if
an element is visible in schematic view.
It is calculated by COALESCE(schema_force_visible, value_list.schema_visible).
This allows direct use of this field in QGIS for rule-based labeling and
fixes performance issues if calculation is done on client side.

* schema_visible field is dropped on network_element as it is not used (was introduced for valves at the origin)
* _schema_visible and schema_force_visible are added to pipe and valve tables by the qwat_sys.fn_enable_schemavisible function
* old function qwat_sys.fn_enable_schemaview is enhanced and renamed