### PR TITLE
fixup for 1.2.8

### DIFF
--- a/update/delta/delta_1.2.8_schema_visible_perf.sql
+++ b/update/delta/delta_1.2.8_schema_visible_perf.sql
@@ -58,15 +58,15 @@ $BODY$
 				_vl_table,
 				_fk_field);
 
-		EXECUTE format('CREATE TRIGGER tr_%1$I_schema_visible_update
-						BEFORE UPDATE OF schema_force_visible, %2$I
+		EXECUTE format('CREATE TRIGGER tr_%1$I_schema_view_update
+						BEFORE UPDATE OF %2$I
 						ON qwat_od.%1$I
 						FOR EACH ROW
   					EXECUTE PROCEDURE qwat_od.ft_%1$I_schema_visible();',
 				_table_name,
 				_fk_field);
 
-		EXECUTE format('CREATE TRIGGER tr_%1$I_schema_visible_insert
+		EXECUTE format('CREATE TRIGGER tr_%1$I_schema_view_insert
 						BEFORE INSERT
 						ON qwat_od.%1$I
 						FOR EACH ROW

--- a/update/verify_upgrade_db.sh
+++ b/update/verify_upgrade_db.sh
@@ -106,7 +106,7 @@ do
         printf "    Processing ${GREEN}$CURRENT_DELTA${NC}, num version = $CURRENT_DELTA_NUM_VERSION ($CURRENT_DELTA_NUM_VERSION_FULL)\n"
         # drop views
         echo $DIR
-        /usr/bin/psql --host $HOST --port 5432 --username "$USER" --no-password -q -d "$TESTCONFORMDB" -f ../../ordinary_data/views/drop_views.sql
+        /usr/bin/psql --host $HOST --port 5432 --username "$USER" --no-password -q -d "$TESTCONFORMDB" -f ./ordinary_data/views/drop_views.sql
 
         # apply update
         /usr/bin/psql -v ON_ERROR_STOP=1 --host $HOST --port 5432 --username "$USER" --no-password -q -d "$TESTCONFORMDB" -f $f
@@ -114,7 +114,7 @@ do
         # recreate views
         echo "Reloading views and functions from last commit"
         export PGSERVICE=$QWATSERVICETESTCONFORM
-        SRID=$SRID ../../ordinary_data/views/insert_views.sh
+        SRID=$SRID ./ordinary_data/views/insert_views.sh
 
         # Check if there is a POST file associated to the delta, if so, store it in the array for later execution
         EXISTS_POST_FILE=$f'.post'
@@ -221,7 +221,7 @@ if [[ $EXITCODE == 0 ]]; then
 
                 # drop views
                 echo $DIR
-                /usr/bin/psql --host $HOST --port 5432 --username "$USER" --no-password -q -d "$DEMODB" -f ../../ordinary_data/views/drop_views.sql
+                /usr/bin/psql --host $HOST --port 5432 --username "$USER" --no-password -q -d "$DEMODB" -f ./ordinary_data/views/drop_views.sql
 
                 # apply update
                 /usr/bin/psql -v ON_ERROR_STOP=1 --host $HOST --port 5432 --username "$USER" --no-password -q -d "$DEMODB" -f $f
@@ -229,7 +229,7 @@ if [[ $EXITCODE == 0 ]]; then
                 # recreate views
                 echo "Reloading views and functions from last commit"
                 export PGSERVICE=$DEMODB
-                SRID=$SRID ../../ordinary_data/views/insert_views.sh
+                SRID=$SRID ./ordinary_data/views/insert_views.sh
 
                 # Check if there is a POST file associated to the delta, if so, store it in the array for later execution
                 EXISTS_POST_FILE=$f'.post'

--- a/update/verify_upgrade_db.sh
+++ b/update/verify_upgrade_db.sh
@@ -61,9 +61,9 @@ cd $DIR
 LATEST_TAG=$(git describe)
 #PROPER_LATEST_TAG=$(echo $LATEST_TAG| cut -d'-' -f 1)
 # SHORT_LATEST_TAG=$(echo $LATEST_TAG| cut -c 1)
-if [[ ${LATEST_TAG:0:1} == "v" ]] ; then 
+if [[ ${LATEST_TAG:0:1} == "v" ]] ; then
     SHORT_LATEST_TAG=$(echo $LATEST_TAG| cut -c2-2)
-else 
+else
     SHORT_LATEST_TAG=$(echo $LATEST_TAG| cut -c 1)
 fi
 printf "    Latest tag = ${GREEN}$SHORT_LATEST_TAG ($LATEST_TAG) ${NC}\n"
@@ -104,7 +104,17 @@ do
     CURRENT_DELTA_NUM_VERSION_FULL=$(echo $CURRENT_DELTA_WITHOUT_EXT| cut -d'_' -f 2)
     if [[ $CURRENT_DELTA_NUM_VERSION > $SHORT_LATEST_TAG || $CURRENT_DELTA_NUM_VERSION == $SHORT_LATEST_TAG || $SHORT_LATEST_TAG == '' ]]; then
         printf "    Processing ${GREEN}$CURRENT_DELTA${NC}, num version = $CURRENT_DELTA_NUM_VERSION ($CURRENT_DELTA_NUM_VERSION_FULL)\n"
+        # drop views
+        echo $DIR
+        /usr/bin/psql --host $HOST --port 5432 --username "$USER" --no-password -q -d "$TESTCONFORMDB" -f ../ordinary_data/views/drop_views.sql
+
+        # apply update
         /usr/bin/psql -v ON_ERROR_STOP=1 --host $HOST --port 5432 --username "$USER" --no-password -q -d "$TESTCONFORMDB" -f $f
+
+        # recreate views
+        echo "Reloading views and functions from last commit"
+        export PGSERVICE=$QWATSERVICETESTCONFORM
+        SRID=$SRID ../ordinary_data/views/insert_views.sh
 
         # Check if there is a POST file associated to the delta, if so, store it in the array for later execution
         EXISTS_POST_FILE=$f'.post'
@@ -208,7 +218,18 @@ if [[ $EXITCODE == 0 ]]; then
             #if [[ $CURRENT_DELTA_NUM_VERSION_FULL > $SAMPLE_VERSION || $CURRENT_DELTA_NUM_VERSION == $SAMPLE_VERSION || $SAMPLE_VERSION == '' ]]; then
             if [[ ($CURRENT_DELTA_NUM_VERSION_FULL > $SAMPLE_VERSION || $SAMPLE_VERSION == '') && $CURRENT_DELTA_NUM_VERSION_FULL != $SAMPLE_VERSION  ]]; then
                 printf "    Processing ${GREEN}$CURRENT_DELTA${NC}, num version = $CURRENT_DELTA_NUM_VERSION_FULL\n"
+
+                # drop views
+                echo $DIR
+                /usr/bin/psql --host $HOST --port 5432 --username "$USER" --no-password -q -d "$DEMODB" -f ../ordinary_data/views/drop_views.sql
+
+                # apply update
                 /usr/bin/psql -v ON_ERROR_STOP=1 --host $HOST --port 5432 --username "$USER" --no-password -q -d "$DEMODB" -f $f
+
+                # recreate views
+                echo "Reloading views and functions from last commit"
+                export PGSERVICE=$DEMODB
+                SRID=$SRID ../ordinary_data/views/insert_views.sh
 
                 # Check if there is a POST file associated to the delta, if so, store it in the array for later execution
                 EXISTS_POST_FILE=$f'.post'
@@ -227,12 +248,7 @@ if [[ $EXITCODE == 0 ]]; then
             LAST_VERSION=$SAMPLE_VERSION
         fi
 
-        # 3 - re-create views & triggers
-        printf "\n${YELLOW}Reloading views and functions${NC}\n"
-
-        export PGSERVICE=$DEMODB
-        SRID=$SRID ./ordinary_data/views/rewrite_views.sh
-        SRID=$SRID ./ordinary_data/functions/rewrite_functions.sh
+        
         # 4 - Execute post delta files if there are
         printf "\n"
         for i in "${TAB_FILES_POST[@]}"

--- a/update/verify_upgrade_db.sh
+++ b/update/verify_upgrade_db.sh
@@ -106,7 +106,7 @@ do
         printf "    Processing ${GREEN}$CURRENT_DELTA${NC}, num version = $CURRENT_DELTA_NUM_VERSION ($CURRENT_DELTA_NUM_VERSION_FULL)\n"
         # drop views
         echo $DIR
-        /usr/bin/psql --host $HOST --port 5432 --username "$USER" --no-password -q -d "$TESTCONFORMDB" -f ../ordinary_data/views/drop_views.sql
+        /usr/bin/psql --host $HOST --port 5432 --username "$USER" --no-password -q -d "$TESTCONFORMDB" -f ../../ordinary_data/views/drop_views.sql
 
         # apply update
         /usr/bin/psql -v ON_ERROR_STOP=1 --host $HOST --port 5432 --username "$USER" --no-password -q -d "$TESTCONFORMDB" -f $f
@@ -114,7 +114,7 @@ do
         # recreate views
         echo "Reloading views and functions from last commit"
         export PGSERVICE=$QWATSERVICETESTCONFORM
-        SRID=$SRID ../ordinary_data/views/insert_views.sh
+        SRID=$SRID ../../ordinary_data/views/insert_views.sh
 
         # Check if there is a POST file associated to the delta, if so, store it in the array for later execution
         EXISTS_POST_FILE=$f'.post'
@@ -221,7 +221,7 @@ if [[ $EXITCODE == 0 ]]; then
 
                 # drop views
                 echo $DIR
-                /usr/bin/psql --host $HOST --port 5432 --username "$USER" --no-password -q -d "$DEMODB" -f ../ordinary_data/views/drop_views.sql
+                /usr/bin/psql --host $HOST --port 5432 --username "$USER" --no-password -q -d "$DEMODB" -f ../../ordinary_data/views/drop_views.sql
 
                 # apply update
                 /usr/bin/psql -v ON_ERROR_STOP=1 --host $HOST --port 5432 --username "$USER" --no-password -q -d "$DEMODB" -f $f
@@ -229,7 +229,7 @@ if [[ $EXITCODE == 0 ]]; then
                 # recreate views
                 echo "Reloading views and functions from last commit"
                 export PGSERVICE=$DEMODB
-                SRID=$SRID ../ordinary_data/views/insert_views.sh
+                SRID=$SRID ../../ordinary_data/views/insert_views.sh
 
                 # Check if there is a POST file associated to the delta, if so, store it in the array for later execution
                 EXISTS_POST_FILE=$f'.post'
@@ -248,7 +248,7 @@ if [[ $EXITCODE == 0 ]]; then
             LAST_VERSION=$SAMPLE_VERSION
         fi
 
-        
+
         # 4 - Execute post delta files if there are
         printf "\n"
         for i in "${TAB_FILES_POST[@]}"


### PR DESCRIPTION
So, delta file for 1.2.8 is fixed, as is upgrade_db.sh script for local updates. it works for migration from 1.2.6 to 1.2.8 at least. 
I couldn't find any working configuration to fix the travis script for all possible use cases because of dependencies to generated view in manual views. 

So, as long as this conformity checking script has a few days to live, I will stop wasting time on that old script, unless someone finds a nice solution to that. 

I'll squash commit history before merge.