### PR TITLE
fix 2 for 1.2.8

### DIFF
--- a/init_qwat.sh
+++ b/init_qwat.sh
@@ -126,7 +126,7 @@ psql -v ON_ERROR_STOP=1 -f ${DIR}/system/versions.sql
 psql -v ON_ERROR_STOP=1 -f ${DIR}/system/versions_insert.sql
 psql -v ON_ERROR_STOP=1 -v SRID=$SRID -f ${DIR}/system/settings_insert.sql
 psql -v ON_ERROR_STOP=1 -f ${DIR}/system/audit.sql
-psql -v ON_ERROR_STOP=1 -f ${DIR}/system/fn_enable_schemaview.sql
+psql -v ON_ERROR_STOP=1 -f ${DIR}/system/fn_enable_schemavisible.sql
 psql -v ON_ERROR_STOP=1 -f ${DIR}/system/fn_label.sql
 psql -v ON_ERROR_STOP=1 -f ${DIR}/system/upgrades_table.sql
 

--- a/system/fn_enable_schemavisible.sql
+++ b/system/fn_enable_schemavisible.sql
@@ -40,7 +40,7 @@ $BODY$
 				_vl_table,
 				_fk_field);
 
-		EXECUTE format('CREATE TRIGGER tr_%1$I_schema_view_update
+		EXECUTE format('CREATE TRIGGER tr_%1$I_schema_visible_update
 						BEFORE UPDATE OF %2$I
 						ON qwat_od.%1$I
 						FOR EACH ROW
@@ -48,7 +48,7 @@ $BODY$
 				_table_name,
 				_fk_field);
 
-		EXECUTE format('CREATE TRIGGER tr_%1$I_schema_view_insert
+		EXECUTE format('CREATE TRIGGER tr_%1$I_schema_visible_insert
 						BEFORE INSERT
 						ON qwat_od.%1$I
 						FOR EACH ROW

--- a/update/delta/delta_1.2.8_schema_visible_perf.sql
+++ b/update/delta/delta_1.2.8_schema_visible_perf.sql
@@ -58,7 +58,7 @@ $BODY$
 				_vl_table,
 				_fk_field);
 
-		EXECUTE format('CREATE TRIGGER tr_%1$I_schema_view_update
+		EXECUTE format('CREATE TRIGGER tr_%1$I_schema_visible_update
 						BEFORE UPDATE OF %2$I
 						ON qwat_od.%1$I
 						FOR EACH ROW
@@ -66,7 +66,7 @@ $BODY$
 				_table_name,
 				_fk_field);
 
-		EXECUTE format('CREATE TRIGGER tr_%1$I_schema_view_insert
+		EXECUTE format('CREATE TRIGGER tr_%1$I_schema_visible_insert
 						BEFORE INSERT
 						ON qwat_od.%1$I
 						FOR EACH ROW


### PR DESCRIPTION
This time, 
changing trigger naming in init process and restore correct naming in delta file. 
Also Rename fn_enable_schemaview.sql to fn_enable_schemavisible.sql and fix init_qwat.sh to use this new name. This will keep naming convention correct. 
The migration works from 1.2.6 on my install up to 1.2.9 using the fixed upgred_db.sh. 

@3nids I'm letting you merge or fix it using another method. 


