### PR TITLE
use a full demo data dump instead of empty Db

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,14 +41,18 @@ script:
   # Get current version
   - export VERSION=$(sed 'r' "$TRAVIS_BUILD_DIR/system/CURRENT_VERSION.txt")
 
-  # Create a qwat 1.0.0 db from a dump file. This simulate the prod db
-  - pum restore -p qwat_prod $TRAVIS_BUILD_DIR/update/delta/qwat_1_0_0_dump.dump
-  - pum baseline -p qwat_prod -t qwat_sys.info -d $TRAVIS_BUILD_DIR/update/delta/ -b 1.0.0
+  # Create a qwat 1.2.1 db from a dump file. This simulate the prod db
+  # Download demo data only dump from 1.2.1
+  - wget -q -O qwat_dump.backup https://github.com/qwat/qwat-data-sample/blob/master/qwat_v1.2.1_data_and_structure_sample.backup
+  
+  # Restoring
+  - pum restore -p qwat_prod qwat_dump.backup
+  - pum baseline -p qwat_prod -t qwat_sys.info -d $TRAVIS_BUILD_DIR/update/delta/ -b 1.2.1
 
   # Run init_qwat.sh to create the last version of qwat db used as comp db
   - printf "travis_fold:start:init_qwat\nInitialize database"
   - $TRAVIS_BUILD_DIR/init_qwat.sh -p qwat_comp -s 21781 -r -n
-  - if [ $? -eq 0 ]; then echo "travis_fold:end:init-qwat"; fi 
+  - if [ $? -eq 0 ]; then echo "travis_fold:end:init-qwat"; fi
   - pum baseline -p qwat_comp -t qwat_sys.info -d $TRAVIS_BUILD_DIR/update/delta/ -b $VERSION
 
   # Run pum's test and upgrade

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ script:
 
   # Create a qwat 1.2.1 db from a dump file. This simulate the prod db
   # Download demo data only dump from 1.2.1
-  - wget -q -O qwat_dump.backup https://github.com/qwat/qwat-data-sample/blob/master/qwat_v1.2.1_data_and_structure_sample.backup
-  
+  - wget -q -O qwat_dump.backup https://github.com/qwat/qwat-data-sample/raw/master/qwat_v1.2.1_data_and_structure_sample.backup
+
   # Restoring
   - pum restore -p qwat_prod qwat_dump.backup
   - pum baseline -p qwat_prod -t qwat_sys.info -d $TRAVIS_BUILD_DIR/update/delta/ -b 1.2.1


### PR DESCRIPTION
using 1.2.1 full dump instead of 1.0.0. This will allow the automatic demo data upgrade. 
We don't have many users in production between 1.0.0 and 1.2.1, so that shouldn't be a big issue not to test each time updates from 1.0.0