### PR TITLE
Missing spatial indexes for some qwat_od's tables

### DIFF
--- a/ordinary_data/installation/od_cover.sql
+++ b/ordinary_data/installation/od_cover.sql
@@ -20,8 +20,12 @@ ALTER TABLE qwat_od.cover ADD COLUMN altitude        numeric(8,3);
 ALTER TABLE qwat_od.cover ADD COLUMN circular        boolean default true;
 ALTER TABLE qwat_od.cover ADD COLUMN form_dimension  decimal(10,3)       ; COMMENT ON COLUMN qwat_od.cover.form_dimension  IS 'depending on the cover form, it represents either the diameter of circle or the length of a square side';
 ALTER TABLE qwat_od.cover ADD COLUMN remark          text                ;
+
+/* GEOMETRY */
 ALTER TABLE qwat_od.cover ADD COLUMN geometry         geometry('PointZ', :SRID) NOT NULL;
 ALTER TABLE qwat_od.cover ADD COLUMN geometry_polygon geometry('Polygon', :SRID);
+CREATE INDEX cover_geoidx ON qwat_od.cover USING GIST ( geometry );
+CREATE INDEX cover_geoidx_polygon ON qwat_od.cover USING GIST ( geometry_polygon );
 
 
 /* LABELS */

--- a/ordinary_data/leak/od_leak.sql
+++ b/ordinary_data/leak/od_leak.sql
@@ -20,8 +20,10 @@ ALTER TABLE qwat_od.leak ADD COLUMN address           text ;
 ALTER TABLE qwat_od.leak ADD COLUMN pipe_replaced     boolean;
 ALTER TABLE qwat_od.leak ADD COLUMN description       text ;
 ALTER TABLE qwat_od.leak ADD COLUMN repair            text ;
-ALTER TABLE qwat_od.leak ADD COLUMN geometry          geometry(Point,:SRID);
 
+/* GEOMETRY */
+ALTER TABLE qwat_od.leak ADD COLUMN geometry          geometry(Point,:SRID);
+CREATE INDEX leak_geoidx ON qwat_od.leak USING GIST ( geometry );
 
 /* LABELS */
 DO $$ BEGIN PERFORM qwat_sys.fn_label_create_fields('leak'); END $$;

--- a/ordinary_data/pipe/od_crossing.sql
+++ b/ordinary_data/pipe/od_crossing.sql
@@ -21,6 +21,7 @@ WITH (
 );
 
 ALTER TABLE qwat_od.crossing ADD COLUMN geometry geometry('POINT',:SRID) NOT NULL;
+CREATE INDEX crossing_geoidx ON qwat_od.crossing USING GIST ( geometry );
 
 CREATE OR REPLACE FUNCTION qwat_od.ft_controled_crossing()
 RETURNS trigger AS

--- a/ordinary_data/surveypoint/od_surveypoint.sql
+++ b/ordinary_data/surveypoint/od_surveypoint.sql
@@ -17,7 +17,11 @@ ALTER TABLE qwat_od.surveypoint ADD COLUMN description      text;
 ALTER TABLE qwat_od.surveypoint ADD COLUMN date             date;
 ALTER TABLE qwat_od.surveypoint ADD COLUMN fk_folder        integer ;
 ALTER TABLE qwat_od.surveypoint ADD COLUMN altitude         decimal(10,3) default null;
+
+/* GEOMETRY */
 ALTER TABLE qwat_od.surveypoint ADD COLUMN geometry         geometry(POINTZ,:SRID);
+CREATE INDEX surveypoint_geoidx ON qwat_od.surveypoint USING GIST ( geometry );
+
 -- TODO add fk_object_reference
 
 /* constraints */

--- a/ordinary_data/valve/od_valve.sql
+++ b/ordinary_data/valve/od_valve.sql
@@ -76,7 +76,6 @@ ALTER TABLE qwat_od.valve ADD COLUMN geometry_alt2 geometry('POINTZ',:SRID);
 ALTER TABLE qwat_od.valve ADD COLUMN update_geometry_alt1 boolean default null; -- used to determine if alternative geometries should be updated when main geometry is updated
 ALTER TABLE qwat_od.valve ADD COLUMN update_geometry_alt2 boolean default null; -- used to determine if alternative geometries should be updated when main geometry is updated
 
-
 /* Schema view */
 DO $$ BEGIN PERFORM qwat_sys.fn_enable_schemavisible('valve', 'valve_function', 'fk_valve_function'); END $$;
 
@@ -87,6 +86,7 @@ DO $$ BEGIN PERFORM qwat_sys.fn_label_create_fields('valve'); END $$;
 CREATE INDEX valve_geoidx ON qwat_od.valve USING GIST ( geometry );
 CREATE INDEX valve_geoidx_alt1 ON qwat_od.valve USING GIST ( geometry_alt1 );
 CREATE INDEX valve_geoidx_alt2 ON qwat_od.valve USING GIST ( geometry_alt2 );
+CREATE INDEX valve_geoidx_handle ON qwat_od.valve USING GIST ( handle_geometry );
 
 /* NODE TRIGGER */
 /*

--- a/update/delta/delta_1.3.2_001_missing_spatial_indexes.sql
+++ b/update/delta/delta_1.3.2_001_missing_spatial_indexes.sql
@@ -1,0 +1,9 @@
+-- Missing spatial indexes
+
+CREATE INDEX cover_geoidx ON qwat_od.cover USING GIST ( geometry );
+CREATE INDEX cover_geoidx_polygon ON qwat_od.cover USING GIST ( geometry_polygon );
+CREATE INDEX crossing_geoidx ON qwat_od.crossing USING GIST ( geometry );
+CREATE INDEX leak_geoidx ON qwat_od.leak USING GIST ( geometry );
+CREATE INDEX surveypoint_geoidx ON qwat_od.surveypoint USING GIST ( geometry );
+CREATE INDEX valve_geoidx_handle ON qwat_od.valve USING GIST ( handle_geometry );
+


### PR DESCRIPTION
Missing spatial indexes for some qwat_od's tables:
* cover - geometry
* cover - geometry_polygon
* crossing - geometry
* leak - geometry
* surveypoint - geometry
* valve - handle_geometry
