### PR TITLE
Deactivate tables auditing during migrations

### DIFF
--- a/system/audit.sql
+++ b/system/audit.sql
@@ -228,11 +228,11 @@ BEGIN
                               and a.attnum = any(i.indkey)
           where i.indrelid = target_table::regclass
             and i.indisprimary
-            ;
+          on conflict do nothing;
 END;
 $body$
 LANGUAGE plpgsql;
- 
+
 COMMENT ON FUNCTION qwat_sys.audit_table(regclass, BOOLEAN, BOOLEAN, text[]) IS $body$
 ADD auditing support TO a TABLE.
  
@@ -258,6 +258,14 @@ $body$ LANGUAGE 'sql';
 COMMENT ON FUNCTION qwat_sys.audit_table(regclass) IS $body$
 Add auditing support to the given table. Row-level changes will be logged with full client query text. No cols are ignored.
 $body$;
+
+CREATE OR REPLACE FUNCTION qwat_sys.unaudit_table(target_table regclass) RETURNS void AS $body$
+BEGIN
+    EXECUTE 'DROP TRIGGER IF EXISTS audit_trigger_row ON ' || target_table::text;
+    EXECUTE 'DROP TRIGGER IF EXISTS audit_trigger_stm ON ' || target_table::text;
+END;
+$body$
+LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION qwat_sys.replay_event(pevent_id int) RETURNS void AS $body$
@@ -347,3 +355,10 @@ Example:
   SELECT qwat_sys.audit_view('qwat_od.vw_element_installation', 'true'::BOOLEAN, '{field_to_ignore}'::text[], '{key_field1, keyfield2}'::text[]) 
 $body$;
  
+CREATE OR REPLACE FUNCTION qwat_sys.unaudit_view(target_view regclass) RETURNS void AS $body$
+BEGIN
+    EXECUTE 'DROP TRIGGER IF EXISTS audit_trigger_row ON ' || target_view::text;
+    EXECUTE 'DROP TRIGGER IF EXISTS audit_trigger_stm ON ' || target_view::text;
+END;
+$body$
+LANGUAGE plpgsql;

--- a/system/audit_tables.sql
+++ b/system/audit_tables.sql
@@ -1,64 +1,86 @@
 /* Audit */
+CREATE OR REPLACE FUNCTION qwat_sys._list_audit_tables() RETURNS text[] AS $body$
+DECLARE
+    tables_to_audit text[];
+BEGIN
+    tables_to_audit := ARRAY[
+        --qwat_dr
+        'qwat_dr.annotationline',
+        'qwat_dr.annotationpoint',
+        'qwat_dr.constructionpoint',
+        'qwat_dr.dimension_distance',
+        'qwat_dr.dimension_orientation',
+        --qwat_od
+        'qwat_od.distributor',
+        'qwat_od.district',
+        'qwat_od.folder',
+        'qwat_od.leak',
+        'qwat_od.pipe',
+        'qwat_od.printmap',
+        'qwat_od.protectionzone',
+        'qwat_od.remote',
+        'qwat_od.surveypoint',
+        'qwat_od.valve',
+        -- qwat_vl
+        'qwat_vl.cistern',
+        'qwat_vl.hydrant_provider',
+        'qwat_vl.hydrant_material',
+        'qwat_vl.leak_cause',
+        'qwat_vl.overflow',
+        'qwat_vl.pipe_function',
+        'qwat_vl.pipe_installmethod',
+        'qwat_vl.pipe_material',
+        'qwat_vl.pipe_protection',
+        'qwat_vl.precision',
+        'qwat_vl.pressurecontrol_type',
+        'qwat_vl.protectionzone_type',
+        'qwat_vl.pump_type',
+        'qwat_vl.remote_type',
+        'qwat_vl.source_quality',
+        'qwat_vl.source_type',
+        'qwat_vl.status',
+        'qwat_vl.subscriber_type',
+        'qwat_vl.survey_type',
+        'qwat_vl.tank_firestorage',
+        'qwat_vl.valve_function',
+        'qwat_vl.valve_maintenance',
+        'qwat_vl.valve_actuation',
+        'qwat_vl.valve_type',
+        'qwat_vl.visible'];
+    return tables_to_audit;
+END
+$body$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION qwat_sys._list_audit_tables() IS $body$
+Return the tables to be audited.
+$body$;
+
+CREATE OR REPLACE FUNCTION qwat_sys.activate_audit_tables() RETURNS void AS $body$
+BEGIN
+    PERFORM qwat_sys.audit_table(t) FROM unnest(qwat_sys._list_audit_tables()) t;
+END
+$body$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION qwat_sys.activate_audit_tables() IS $body$
+Activate auditing of tables.
+$body$;
+
+CREATE OR REPLACE FUNCTION qwat_sys.deactivate_audit_tables() RETURNS void AS $body$
+BEGIN
+    PERFORM qwat_sys.unaudit_table(t) FROM unnest(qwat_sys._list_audit_tables()) t;
+END
+$body$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION qwat_sys.deactivate_audit_tables() IS $body$
+Deactivate auditing of tables.
+$body$;
+
+
 DO $$
 BEGIN
---qwat_dr
-PERFORM qwat_sys.audit_table('qwat_dr.annotationline');
-PERFORM qwat_sys.audit_table('qwat_dr.annotationpoint');
-PERFORM qwat_sys.audit_table('qwat_dr.constructionpoint');
-PERFORM qwat_sys.audit_table('qwat_dr.dimension_distance');
-PERFORM qwat_sys.audit_table('qwat_dr.dimension_orientation');
-
---qwat_od
-
-PERFORM qwat_sys.audit_table('qwat_od.distributor');
-PERFORM qwat_sys.audit_table('qwat_od.district');
-PERFORM qwat_sys.audit_table('qwat_od.folder');
--- PERFORM qwat_sys.audit_table('qwat_od.hydrant');
--- PERFORM qwat_sys.audit_table('qwat_od.installation');
--- PERFORM qwat_sys.audit_table('qwat_od.pressurecontrol');
--- PERFORM qwat_sys.audit_table('qwat_od.pump');
--- PERFORM qwat_sys.audit_table('qwat_od.source');
--- PERFORM qwat_sys.audit_table('qwat_od.treatment');
--- PERFORM qwat_sys.audit_table('qwat_od.tank');
--- PERFORM qwat_sys.audit_table('qwat_od.chamber');
-PERFORM qwat_sys.audit_table('qwat_od.leak');
--- PERFORM qwat_sys.audit_table('qwat_od.meter');
-PERFORM qwat_sys.audit_table('qwat_od.pipe');
--- PERFORM qwat_sys.audit_table('qwat_od.pressurezone');
-PERFORM qwat_sys.audit_table('qwat_od.printmap');
-PERFORM qwat_sys.audit_table('qwat_od.protectionzone');
-PERFORM qwat_sys.audit_table('qwat_od.remote');
--- PERFORM qwat_sys.audit_table('qwat_od.samplingpoint');
--- PERFORM qwat_sys.audit_table('qwat_od.subscriber');
--- PERFORM qwat_sys.audit_table('qwat_od.subscriber_reference');
-PERFORM qwat_sys.audit_table('qwat_od.surveypoint');
-PERFORM qwat_sys.audit_table('qwat_od.valve');
-
--- qwat_vl
-PERFORM qwat_sys.audit_table('qwat_vl.cistern');
-PERFORM qwat_sys.audit_table('qwat_vl.hydrant_provider');
-PERFORM qwat_sys.audit_table('qwat_vl.hydrant_material');
-PERFORM qwat_sys.audit_table('qwat_vl.leak_cause');
-PERFORM qwat_sys.audit_table('qwat_vl.overflow');
-PERFORM qwat_sys.audit_table('qwat_vl.pipe_function');
-PERFORM qwat_sys.audit_table('qwat_vl.pipe_installmethod');
-PERFORM qwat_sys.audit_table('qwat_vl.pipe_material');
-PERFORM qwat_sys.audit_table('qwat_vl.pipe_protection');
-PERFORM qwat_sys.audit_table('qwat_vl.precision');
-PERFORM qwat_sys.audit_table('qwat_vl.pressurecontrol_type');
-PERFORM qwat_sys.audit_table('qwat_vl.protectionzone_type');
-PERFORM qwat_sys.audit_table('qwat_vl.pump_type');
-PERFORM qwat_sys.audit_table('qwat_vl.remote_type');
-PERFORM qwat_sys.audit_table('qwat_vl.source_quality');
-PERFORM qwat_sys.audit_table('qwat_vl.source_type');
-PERFORM qwat_sys.audit_table('qwat_vl.status');
-PERFORM qwat_sys.audit_table('qwat_vl.subscriber_type');
-PERFORM qwat_sys.audit_table('qwat_vl.survey_type');
-PERFORM qwat_sys.audit_table('qwat_vl.tank_firestorage');
-PERFORM qwat_sys.audit_table('qwat_vl.valve_function');
-PERFORM qwat_sys.audit_table('qwat_vl.valve_maintenance');
-PERFORM qwat_sys.audit_table('qwat_vl.valve_actuation');
-PERFORM qwat_sys.audit_table('qwat_vl.valve_type');
-PERFORM qwat_sys.audit_table('qwat_vl.visible');
+    PERFORM qwat_sys.activate_audit_tables();
 END
 $$;

--- a/system/audit_views.sql
+++ b/system/audit_views.sql
@@ -1,27 +1,55 @@
 /* Audit views only for those having explicit triggers handling data editing*/
+CREATE OR REPLACE FUNCTION qwat_sys._list_audit_views() RETURNS text[] AS $body$
+DECLARE
+    views_to_audit text[];
+BEGIN
+    views_to_audit := ARRAY[
+        'qwat_od.vw_consumptionzone',
+        'qwat_od.vw_element_hydrant',
+        'qwat_od.vw_element_installation',
+        'qwat_od.vw_element_meter',
+        'qwat_od.vw_element_part',
+        'qwat_od.vw_element_samplingpoint',
+        'qwat_od.vw_element_subscriber',
+        'qwat_od.vw_protectionzone',
+        'qwat_od.vw_qwat_installation',
+        'qwat_od.vw_qwat_network_element',
+        'qwat_od.vw_qwat_node'];
+    return views_to_audit;
+END
+$body$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION qwat_sys._list_audit_views() IS $body$
+Return the views to be audited.
+$body$;
+
+CREATE OR REPLACE FUNCTION qwat_sys.activate_audit_views() RETURNS void AS $body$
+BEGIN
+    PERFORM qwat_sys.audit_view(t, 'true'::boolean, '{}'::text[], '{id}'::text[])
+            FROM unnest(qwat_sys._list_audit_views()) t;
+END
+$body$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION qwat_sys.activate_audit_views() IS $body$
+Activate auditing of views.
+$body$;
+
+CREATE OR REPLACE FUNCTION qwat_sys.deactivate_audit_views() RETURNS void AS $body$
+BEGIN
+    PERFORM qwat_sys.unaudit_view(t) FROM unnest(qwat_sys._list_audit_views()) t;
+END
+$body$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION qwat_sys.deactivate_audit_views() IS $body$
+Deactivate auditing of views.
+$body$;
+
+
 DO $$
 BEGIN
-PERFORM qwat_sys.audit_view('qwat_od.vw_consumptionzone', 'true'::boolean, '{}'::text[], '{id}'::text[]);
-PERFORM qwat_sys.audit_view('qwat_od.vw_element_hydrant', 'true'::boolean, '{}'::text[], '{id}'::text[]);
-PERFORM qwat_sys.audit_view('qwat_od.vw_element_installation', 'true'::boolean, '{}'::text[], '{id}'::text[]);
-PERFORM qwat_sys.audit_view('qwat_od.vw_element_meter', 'true'::boolean, '{}'::text[], '{id}'::text[]);
-PERFORM qwat_sys.audit_view('qwat_od.vw_element_part', 'true'::boolean, '{}'::text[], '{id}'::text[]);
-PERFORM qwat_sys.audit_view('qwat_od.vw_element_samplingpoint', 'true'::boolean, '{}'::text[], '{id}'::text[]);
-PERFORM qwat_sys.audit_view('qwat_od.vw_element_subscriber', 'true'::boolean, '{}'::text[], '{id}'::text[]);
--- PERFORM qwat_sys.audit_view('qwat_od.vw_node_element', 'true'::boolean, '{}'::text[], '{id}'::text[]);
--- PERFORM qwat_sys.audit_view('qwat_od.vw_pipe_child_parent', 'true'::boolean, '{}'::text[], '{id}'::text[]);
--- PERFORM qwat_sys.audit_view('qwat_od.vw_pipe_schema_merged', 'true'::boolean, '{}'::text[], '{id}'::text[]);
--- PERFORM qwat_sys.audit_view('qwat_od.vw_pipe_schema', 'true'::boolean, '{}'::text[], '{id}'::text[]);
--- PERFORM qwat_sys.audit_view('qwat_od.vw_pipe_schema_error', 'true'::boolean, '{}'::text[], '{id}'::text[]);
--- PERFORM qwat_sys.audit_view('qwat_od.vw_pipe_schema_visibleitems', 'true'::boolean, '{}'::text[], '{id}'::text[]);
--- PERFORM qwat_sys.audit_view('qwat_od.vw_printmap', 'true'::boolean, '{}'::text[], '{id}'::text[]);
-PERFORM qwat_sys.audit_view('qwat_od.vw_protectionzone', 'true'::boolean, '{}'::text[], '{id}'::text[]);
-PERFORM qwat_sys.audit_view('qwat_od.vw_qwat_installation', 'true'::boolean, '{}'::text[], '{id}'::text[]);
-PERFORM qwat_sys.audit_view('qwat_od.vw_qwat_network_element', 'true'::boolean, '{}'::text[], '{id}'::text[]);
-PERFORM qwat_sys.audit_view('qwat_od.vw_qwat_node', 'true'::boolean, '{}'::text[], '{id}'::text[]);
--- PERFORM qwat_sys.audit_view('qwat_od.vw_remote', 'true'::boolean, '{}'::text[], '{id}'::text[]);
--- PERFORM qwat_sys.audit_view('qwat_od.vw_search_view', 'true'::boolean, '{}'::text[], '{id}'::text[]);
--- PERFORM qwat_sys.audit_view('qwat_od.vw_subscriber_pipe_relation', 'true'::boolean, '{}'::text[], '{id}'::text[]);
--- PERFORM qwat_sys.audit_view('qwat_od.vw_valve_lines', 'true'::boolean, '{}'::text[], '{id}'::text[]);
+    PERFORM qwat_sys.activate_audit_views();
 END
 $$;

--- a/update/delta/delta_1.3.2_004_auditing_functions.sql
+++ b/update/delta/delta_1.3.2_004_auditing_functions.sql
@@ -1,0 +1,188 @@
+CREATE OR REPLACE FUNCTION qwat_sys.audit_table(target_table regclass, audit_rows BOOLEAN, audit_query_text BOOLEAN, ignored_cols text[]) RETURNS void AS $body$
+DECLARE
+  stm_targets text = 'INSERT OR UPDATE OR DELETE OR TRUNCATE';
+  _q_txt text;
+  _ignored_cols_snip text = '';
+BEGIN
+    EXECUTE 'DROP TRIGGER IF EXISTS audit_trigger_row ON ' || target_table::text;
+    EXECUTE 'DROP TRIGGER IF EXISTS audit_trigger_stm ON ' || target_table::text;
+ 
+    IF audit_rows THEN
+        IF array_length(ignored_cols,1) > 0 THEN
+            _ignored_cols_snip = ', ' || quote_literal(ignored_cols);
+        END IF;
+        _q_txt = 'CREATE TRIGGER audit_trigger_row AFTER INSERT OR UPDATE OR DELETE ON ' || 
+                 target_table::text || 
+                 ' FOR EACH ROW EXECUTE PROCEDURE qwat_sys.if_modified_func(' ||
+                 quote_literal(audit_query_text) || _ignored_cols_snip || ');';
+        RAISE NOTICE '%',_q_txt;
+        EXECUTE _q_txt;
+        stm_targets = 'TRUNCATE';
+    ELSE
+    END IF;
+ 
+    _q_txt = 'CREATE TRIGGER audit_trigger_stm AFTER ' || stm_targets || ' ON ' ||
+             target_table ||
+             ' FOR EACH STATEMENT EXECUTE PROCEDURE qwat_sys.if_modified_func('||
+             quote_literal(audit_query_text) || ');';
+    RAISE NOTICE '%',_q_txt;
+    EXECUTE _q_txt;
+
+    -- store primary key names
+    insert into qwat_sys.logged_relations (relation_name, uid_column)
+         select target_table, a.attname
+           from pg_index i
+           join pg_attribute a on a.attrelid = i.indrelid
+                              and a.attnum = any(i.indkey)
+          where i.indrelid = target_table::regclass
+            and i.indisprimary
+          on conflict do nothing;
+END;
+$body$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION qwat_sys.unaudit_table(target_table regclass) RETURNS void AS $body$
+BEGIN
+    EXECUTE 'DROP TRIGGER IF EXISTS audit_trigger_row ON ' || target_table::text;
+    EXECUTE 'DROP TRIGGER IF EXISTS audit_trigger_stm ON ' || target_table::text;
+END;
+$body$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION qwat_sys.unaudit_view(target_view regclass) RETURNS void AS $body$
+BEGIN
+    EXECUTE 'DROP TRIGGER IF EXISTS audit_trigger_row ON ' || target_view::text;
+    EXECUTE 'DROP TRIGGER IF EXISTS audit_trigger_stm ON ' || target_view::text;
+END;
+$body$
+LANGUAGE plpgsql;
+
+
+/* Audit */
+CREATE OR REPLACE FUNCTION qwat_sys._list_audit_tables() RETURNS text[] AS $body$
+DECLARE
+    tables_to_audit text[];
+BEGIN
+    tables_to_audit := ARRAY[
+        --qwat_dr
+        'qwat_dr.annotationline',
+        'qwat_dr.annotationpoint',
+        'qwat_dr.constructionpoint',
+        'qwat_dr.dimension_distance',
+        'qwat_dr.dimension_orientation',
+        --qwat_od
+        'qwat_od.distributor',
+        'qwat_od.district',
+        'qwat_od.folder',
+        'qwat_od.leak',
+        'qwat_od.pipe',
+        'qwat_od.printmap',
+        'qwat_od.protectionzone',
+        'qwat_od.remote',
+        'qwat_od.surveypoint',
+        'qwat_od.valve',
+        -- qwat_vl
+        'qwat_vl.cistern',
+        'qwat_vl.hydrant_provider',
+        'qwat_vl.hydrant_material',
+        'qwat_vl.leak_cause',
+        'qwat_vl.overflow',
+        'qwat_vl.pipe_function',
+        'qwat_vl.pipe_installmethod',
+        'qwat_vl.pipe_material',
+        'qwat_vl.pipe_protection',
+        'qwat_vl.precision',
+        'qwat_vl.pressurecontrol_type',
+        'qwat_vl.protectionzone_type',
+        'qwat_vl.pump_type',
+        'qwat_vl.remote_type',
+        'qwat_vl.source_quality',
+        'qwat_vl.source_type',
+        'qwat_vl.status',
+        'qwat_vl.subscriber_type',
+        'qwat_vl.survey_type',
+        'qwat_vl.tank_firestorage',
+        'qwat_vl.valve_function',
+        'qwat_vl.valve_maintenance',
+        'qwat_vl.valve_actuation',
+        'qwat_vl.valve_type',
+        'qwat_vl.visible'];
+    return tables_to_audit;
+END
+$body$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION qwat_sys._list_audit_tables() IS $body$
+Return the tables to be audited.
+$body$;
+
+CREATE OR REPLACE FUNCTION qwat_sys.activate_audit_tables() RETURNS void AS $body$
+BEGIN
+    PERFORM qwat_sys.audit_table(t) FROM unnest(qwat_sys._list_audit_tables()) t;
+END
+$body$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION qwat_sys.activate_audit_tables() IS $body$
+Activate auditing of tables.
+$body$;
+
+CREATE OR REPLACE FUNCTION qwat_sys.deactivate_audit_tables() RETURNS void AS $body$
+BEGIN
+    PERFORM qwat_sys.unaudit_table(t) FROM unnest(qwat_sys._list_audit_tables()) t;
+END
+$body$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION qwat_sys.deactivate_audit_tables() IS $body$
+Deactivate auditing of tables.
+$body$;
+
+/* Audit views only for those having explicit triggers handling data editing*/
+CREATE OR REPLACE FUNCTION qwat_sys._list_audit_views() RETURNS text[] AS $body$
+DECLARE
+    views_to_audit text[];
+BEGIN
+    views_to_audit := ARRAY[
+        'qwat_od.vw_consumptionzone',
+        'qwat_od.vw_element_hydrant',
+        'qwat_od.vw_element_installation',
+        'qwat_od.vw_element_meter',
+        'qwat_od.vw_element_part',
+        'qwat_od.vw_element_samplingpoint',
+        'qwat_od.vw_element_subscriber',
+        'qwat_od.vw_protectionzone',
+        'qwat_od.vw_qwat_installation',
+        'qwat_od.vw_qwat_network_element',
+        'qwat_od.vw_qwat_node'];
+    return views_to_audit;
+END
+$body$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION qwat_sys._list_audit_views() IS $body$
+Return the views to be audited.
+$body$;
+
+CREATE OR REPLACE FUNCTION qwat_sys.activate_audit_views() RETURNS void AS $body$
+BEGIN
+    PERFORM qwat_sys.audit_view(t, 'true'::boolean, '{}'::text[], '{id}'::text[])
+            FROM unnest(qwat_sys._list_audit_views()) t;
+END
+$body$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION qwat_sys.activate_audit_views() IS $body$
+Activate auditing of views.
+$body$;
+
+CREATE OR REPLACE FUNCTION qwat_sys.deactivate_audit_views() RETURNS void AS $body$
+BEGIN
+    PERFORM qwat_sys.unaudit_view(t) FROM unnest(qwat_sys._list_audit_views()) t;
+END
+$body$
+LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION qwat_sys.deactivate_audit_views() IS $body$
+Deactivate auditing of views.
+$body$;

--- a/update/delta/post-all.sql
+++ b/update/delta/post-all.sql
@@ -1,0 +1,5 @@
+DO $$
+BEGIN
+    PERFORM qwat_sys.activate_audit_tables();
+END
+$$;

--- a/update/delta/pre-all.sql
+++ b/update/delta/pre-all.sql
@@ -1,0 +1,14 @@
+DO $$
+BEGIN
+
+    -- before 1.3.2 deactivate_audit_tables did not exist, so we test that the function
+    -- exists prior to calling it
+
+    IF EXISTS (SELECT 1
+               FROM pg_proc pp JOIN pg_namespace pn ON (pp.pronamespace = pn.oid)
+               WHERE pp.proname='deactivate_audit_tables' AND pn.nspname='qwat_sys') THEN
+        PERFORM qwat_sys.deactivate_audit_tables();
+    END IF;
+
+END
+$$


### PR DESCRIPTION
Fixes https://github.com/qwat/QWAT/issues/248.

Depends on #232, which should be merged first.