### PR TITLE
Update requirements.txt: psycopg2->psycopg2-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pum
-psycopg2
+psycopg2-binary
 pyyaml


### PR DESCRIPTION
The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead.