### PR TITLE
Make the Travis build stop on pum errors

### DIFF
--- a/.build/travis_before_script.sh
+++ b/.build/travis_before_script.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "SET client_min_messages TO WARNING;" > ~/.psqlrc
+
+cat > ~/.pg_service.conf << EOF
+[qwat_prod]
+host=localhost
+dbname=qwat_prod
+user=postgres
+
+[qwat_test]
+host=localhost
+dbname=qwat_test
+user=postgres
+
+[qwat_comp]
+host=localhost
+dbname=qwat_comp
+user=postgres
+EOF
+
+psql -U postgres -c 'CREATE DATABASE qwat_prod'
+psql -U postgres -c 'CREATE DATABASE qwat_test'
+psql -U postgres -c 'CREATE DATABASE qwat_comp'
+
+psql -U postgres -c 'CREATE ROLE qwat_viewer NOSUPERUSER INHERIT NOCREATEDB NOCREATEROLE NOREPLICATION'
+psql -U postgres -c 'CREATE ROLE qwat_user NOSUPERUSER INHERIT NOCREATEDB NOCREATEROLE NOREPLICATION'
+psql -U postgres -c 'CREATE ROLE qwat_manager NOSUPERUSER INHERIT NOCREATEDB NOCREATEROLE NOREPLICATION'
+psql -U postgres -c 'CREATE ROLE qwat_sysadmin NOSUPERUSER INHERIT NOCREATEDB NOCREATEROLE NOREPLICATION'
+
+pg_dump -V
+pg_restore -V
+
+exit 0

--- a/.build/travis_before_script.sh
+++ b/.build/travis_before_script.sh
@@ -4,23 +4,6 @@ set -e
 
 echo "SET client_min_messages TO WARNING;" > ~/.psqlrc
 
-cat > ~/.pg_service.conf << EOF
-[qwat_prod]
-host=localhost
-dbname=qwat_prod
-user=postgres
-
-[qwat_test]
-host=localhost
-dbname=qwat_test
-user=postgres
-
-[qwat_comp]
-host=localhost
-dbname=qwat_comp
-user=postgres
-EOF
-
 psql -U postgres -c 'CREATE DATABASE qwat_prod'
 psql -U postgres -c 'CREATE DATABASE qwat_test'
 psql -U postgres -c 'CREATE DATABASE qwat_comp'

--- a/.build/travis_script.sh
+++ b/.build/travis_script.sh
@@ -9,6 +9,26 @@ export VERSION=$(sed 'r' "$TRAVIS_BUILD_DIR/system/CURRENT_VERSION.txt")
 # Get the 1.2.1 data_and_structure dump
 wget -q -O qwat_dump.backup https://github.com/qwat/qwat-data-sample/raw/master/qwat_v1.2.1_data_and_structure_sample.backup
 
+# Create a PostgreSQL service file and export the PGSERVICEFILE environment variable
+PGSERVICEFILE="/tmp/pg_service.conf"
+cat > $PGSERVICEFILE << EOF
+[qwat_prod]
+host=localhost
+dbname=qwat_prod
+user=postgres
+
+[qwat_test]
+host=localhost
+dbname=qwat_test
+user=postgres
+
+[qwat_comp]
+host=localhost
+dbname=qwat_comp
+user=postgres
+EOF
+export PGSERVICEFILE
+
 # Restore the 1.2.1 dump in the prod database
 pum restore -p qwat_prod qwat_dump.backup
 

--- a/.build/travis_script.sh
+++ b/.build/travis_script.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd $TRAVIS_BUILD_DIR
+
+export VERSION=$(sed 'r' "$TRAVIS_BUILD_DIR/system/CURRENT_VERSION.txt")
+
+# Get the 1.2.1 data_and_structure dump
+wget -q -O qwat_dump.backup https://github.com/qwat/qwat-data-sample/raw/master/qwat_v1.2.1_data_and_structure_sample.backup
+
+# Restore the 1.2.1 dump in the prod database
+pum restore -p qwat_prod qwat_dump.backup
+
+# Set the baseline for the prod database
+pum baseline -p qwat_prod -t qwat_sys.info -d $TRAVIS_BUILD_DIR/update/delta/ -b 1.2.1
+
+# Run init_qwat.sh to create the last version of qwat db used as the comp database
+printf "travis_fold:start:init_qwat\nInitialize database"
+$TRAVIS_BUILD_DIR/init_qwat.sh -p qwat_comp -s 21781 -r -n
+echo "travis_fold:end:init-qwat"
+
+# Set the baseline for the comp database
+pum baseline -p qwat_comp -t qwat_sys.info -d $TRAVIS_BUILD_DIR/update/delta/ -b $VERSION
+
+# Run test_and_upgrade
+printf "travis_fold:start:test-and-upgrade\nRun test and upgrade"
+yes | pum test-and-upgrade -pp qwat_prod -pt qwat_test -pc qwat_comp -t qwat_sys.info -d $TRAVIS_BUILD_DIR/update/delta/ -f /tmp/qwat_dump -i views rules
+echo "travis_fold:end:test-and-upgrade"
+
+# Run a last check between qwat_prod and qwat_comp
+pum check -p1 qwat_prod -p2 qwat_comp -i views rules
+
+exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,50 +20,10 @@ install:
   - pip install -r requirements.txt
 
 before_script:
-  - echo "SET client_min_messages TO WARNING;" > ~/.psqlrc
-  # Write into pg_service.conf
-  - printf "[qwat_prod]\nhost=localhost\ndbname=qwat_prod\nuser=postgres\n\n[qwat_test]\nhost=localhost\ndbname=qwat_test\nuser=postgres\n\n[qwat_comp]\nhost=localhost\ndbname=qwat_comp\nuser=postgres\n\n[qwat_demo]\nhost=localhost\ndbname=qwat_demo\nuser=postgres\n\n" > ~/.pg_service.conf
-  # Create the 3 used databases
-  - psql -c 'CREATE DATABASE qwat_prod;' -U postgres
-  - psql -c 'CREATE DATABASE qwat_test;' -U postgres
-  - psql -c 'CREATE DATABASE qwat_comp;' -U postgres
-
-  - psql -c 'CREATE ROLE qwat_viewer NOSUPERUSER INHERIT NOCREATEDB NOCREATEROLE NOREPLICATION;' -U postgres
-  - psql -c 'CREATE ROLE qwat_user NOSUPERUSER INHERIT NOCREATEDB NOCREATEROLE NOREPLICATION;' -U postgres
-  - psql -c 'CREATE ROLE qwat_manager NOSUPERUSER INHERIT NOCREATEDB NOCREATEROLE NOREPLICATION;' -U postgres
-  - psql -c 'CREATE ROLE qwat_sysadmin NOSUPERUSER INHERIT NOCREATEDB NOCREATEROLE NOREPLICATION;' -U postgres
-  - pg_dump -V
-  - pg_restore -V
+  - $TRAVIS_BUILD_DIR/.build/travis_before_script.sh
 
 script:
-  - cd $TRAVIS_BUILD_DIR/
-
-  # Get current version
-  - export VERSION=$(sed 'r' "$TRAVIS_BUILD_DIR/system/CURRENT_VERSION.txt")
-
-  # Create a qwat 1.2.1 db from a dump file. This simulate the prod db
-  # Download demo data only dump from 1.2.1
-  - wget -q -O qwat_dump.backup https://github.com/qwat/qwat-data-sample/raw/master/qwat_v1.2.1_data_and_structure_sample.backup
-
-  # Restoring
-  - pum restore -p qwat_prod qwat_dump.backup
-  - pum baseline -p qwat_prod -t qwat_sys.info -d $TRAVIS_BUILD_DIR/update/delta/ -b 1.2.1
-
-  # Run init_qwat.sh to create the last version of qwat db used as comp db
-  - printf "travis_fold:start:init_qwat\nInitialize database"
-  - $TRAVIS_BUILD_DIR/init_qwat.sh -p qwat_comp -s 21781 -r -n
-  - if [ $? -eq 0 ]; then echo "travis_fold:end:init-qwat"; fi
-  - pum baseline -p qwat_comp -t qwat_sys.info -d $TRAVIS_BUILD_DIR/update/delta/ -b $VERSION
-
-  # Run pum's test and upgrade
-  - printf "travis_fold:start:test-and-upgrade\nRun test and upgrade"
-  #- yes | pum test-and-upgrade -pp qwat_prod -pt qwat_test -pc qwat_comp -t qwat_sys.info -d $TRAVIS_BUILD_DIR/update/delta/ -f /tmp/qwat_dump -i columns constraints views sequences indexes triggers functions rules
-  - yes | pum test-and-upgrade -pp qwat_prod -pt qwat_test -pc qwat_comp -t qwat_sys.info -d $TRAVIS_BUILD_DIR/update/delta/ -f /tmp/qwat_dump -i views rules
-  - if [ $? -eq 0 ]; then echo "travis_fold:end:test-and-upgrade"; fi
-
-  # Run a last check between qwat_prod and qwat_comp
-  #- pum check -p1 qwat_prod -p2 qwat_comp -i columns constraints views sequences indexes triggers functions rules
-  - pum check -p1 qwat_prod -p2 qwat_comp -i views rules
+  - $TRAVIS_BUILD_DIR/.build/travis_script.sh
 
 env:
   global:


### PR DESCRIPTION
This WIP at the moment.

Currently the Travis will continue when one of the steps fails in the `script` part. Instead we want the Travis build to stop as soon as something fails. So this PR introduces a `travis_script.sh` script to fix the problem. I also created `travis_before_script.sh` for consistency reasons and to make the code clearer.