### PR TITLE
Make Travis create structure-only dumps

### DIFF
--- a/.deploy/create_release.py
+++ b/.deploy/create_release.py
@@ -141,6 +141,42 @@ def create_dumps():
     files.append(dumpfile)
     print('travis_fold:end:{}'.format(dump))
 
+    dump = 'qwat_v{version}_value_list_data_only.backup'.format(
+        version=os.environ['TRAVIS_TAG'])
+    print('travis_fold:start:{}'.format(dump))
+    print('Creating dump {}'.format(dump))
+    dumpfile = '/tmp/{dump}'.format(dump=dump)
+    subprocess.call(['pg_dump',
+                     '--format', 'custom',
+                     '--blobs',
+                     '--compress', '5',
+                     '--data-only',
+                     '--verbose',
+                     '--file', dumpfile,
+                     '--schema', 'qwat_vl',
+                     'qwat_prod']
+                    )
+    files.append(dumpfile)
+    print('travis_fold:end:{}'.format(dump))
+
+    dump='qwat_v{version}_value_list_data_only_sample.sql'.format(
+        version=os.environ['TRAVIS_TAG'])
+    print('travis_fold:start:{}'.format(dump))
+    print('Creating dump {}'.format(dump))
+    dumpfile='/tmp/{dump}'.format(dump=dump)
+
+    subprocess.call(['pg_dump',
+                     '--format', 'plain',
+                     '--blobs',
+                     '--data-only',
+                     '--verbose',
+                     '--file', dumpfile,
+                     '--schema', 'qwat_vl',
+                     'qwat_prod']
+                    )
+    files.append(dumpfile)
+    print('travis_fold:end:{}'.format(dump))
+
     return files
 
 

--- a/.deploy/create_release.py
+++ b/.deploy/create_release.py
@@ -34,6 +34,8 @@ import subprocess
 def create_dumps():
     files = []
 
+    # Create data-only dumps (with sample data)
+
     dump = 'qwat_v{version}_data_only_sample.backup'.format(
         version=os.environ['TRAVIS_TAG'])
     print('travis_fold:start:{}'.format(dump))
@@ -72,6 +74,8 @@ def create_dumps():
     files.append(dumpfile)
     print('travis_fold:end:{}'.format(dump))
 
+    # Create data + structure dumps (with sample data)
+
     dump='qwat_v{version}_data_and_structure_sample.backup'.format(
         version=os.environ['TRAVIS_TAG'])
     print('travis_fold:start:{}'.format(dump))
@@ -107,6 +111,8 @@ def create_dumps():
     files.append(dumpfile)
     print('travis_fold:end:{}'.format(dump))
 
+    # Create structure-only dumps
+
     dump='qwat_v{version}_structure_only.backup'.format(
         version=os.environ['TRAVIS_TAG'])
     print('travis_fold:start:{}'.format(dump))
@@ -140,6 +146,8 @@ def create_dumps():
                     )
     files.append(dumpfile)
     print('travis_fold:end:{}'.format(dump))
+
+    # Create value-list data only dumps (the qwat_vl schema)
 
     dump = 'qwat_v{version}_value_list_data_only.backup'.format(
         version=os.environ['TRAVIS_TAG'])

--- a/.deploy/create_release.py
+++ b/.deploy/create_release.py
@@ -107,6 +107,40 @@ def create_dumps():
     files.append(dumpfile)
     print('travis_fold:end:{}'.format(dump))
 
+    dump='qwat_v{version}_structure_only.backup'.format(
+        version=os.environ['TRAVIS_TAG'])
+    print('travis_fold:start:{}'.format(dump))
+    print('Creating dump {}'.format(dump))
+    dumpfile='/tmp/{dump}'.format(dump=dump)
+
+    subprocess.call(['pg_dump',
+                     '--format', 'custom',
+                     '--schema-only',
+                     '--verbose',
+                     '--file', dumpfile,
+                     '-N', 'public',
+                     'qwat_prod']
+                    )
+    files.append(dumpfile)
+    print('travis_fold:end:{}'.format(dump))
+
+    dump='qwat_v{version}_structure_only.sql'.format(
+        version=os.environ['TRAVIS_TAG'])
+    print('travis_fold:start:{}'.format(dump))
+    print('Creating dump {}'.format(dump))
+    dumpfile='/tmp/{dump}'.format(dump=dump)
+
+    subprocess.call(['pg_dump',
+                     '--format', 'plain',
+                     '--schema-only',
+                     '--verbose',
+                     '--file', dumpfile,
+                     '-N', 'public',
+                     'qwat_prod']
+                    )
+    files.append(dumpfile)
+    print('travis_fold:end:{}'.format(dump))
+
     return files
 
 


### PR DESCRIPTION
This modifies the `create_release.py` script to also create structure-only dumps. Structure-only dumps are useful when one wants to get an empty QWAT database without having to clone the Git repo and run `init_qwat.sh`.

As discussed @lbartoletti will take care of updating the docs to take this setup path into account.