### PR TITLE
Fix value_list_data_only dump name

### DIFF
--- a/.deploy/create_release.py
+++ b/.deploy/create_release.py
@@ -167,7 +167,7 @@ def create_dumps():
     files.append(dumpfile)
     print('travis_fold:end:{}'.format(dump))
 
-    dump='qwat_v{version}_value_list_data_only_sample.sql'.format(
+    dump='qwat_v{version}_value_list_data_only.sql'.format(
         version=os.environ['TRAVIS_TAG'])
     print('travis_fold:start:{}'.format(dump))
     print('Creating dump {}'.format(dump))


### PR DESCRIPTION
I updated the dump file name on the 1.3.2 release page.