### PR TITLE
Exercise Pum's multi delta dir feature in Travis

### DIFF
--- a/.build/travis_script.sh
+++ b/.build/travis_script.sh
@@ -29,23 +29,37 @@ user=postgres
 EOF
 export PGSERVICEFILE
 
+# Use an extra delta directory with an extra delta file to exercise Pum's
+# multi delta dir feature
+EXTRA_DELTA_DIR="/tmp/delta/"
+EXTRA_DELTA_FILE="$EXTRA_DELTA_DIR/delta_1.2.1_extra_delta_for_test.sql"
+
+DELTA_DIRS="$TRAVIS_BUILD_DIR/update/delta/ $EXTRA_DELTA_DIR"
+
+mkdir -p $EXTRA_DELTA_DIR
+
+cat > $EXTRA_DELTA_FILE << EOF
+CREATE TABLE qwat_table_test_ (qwat_column_test_ text);
+EOF
+
 # Restore the 1.2.1 dump in the prod database
 pum restore -p qwat_prod qwat_dump.backup
 
 # Set the baseline for the prod database
-pum baseline -p qwat_prod -t qwat_sys.info -d $TRAVIS_BUILD_DIR/update/delta/ -b 1.2.1
+pum baseline -p qwat_prod -t qwat_sys.info -d $DELTA_DIRS -b 1.2.1
 
 # Run init_qwat.sh to create the last version of qwat db used as the comp database
 printf "travis_fold:start:init_qwat\nInitialize database"
 $TRAVIS_BUILD_DIR/init_qwat.sh -p qwat_comp -s 21781 -r -n
+psql service=qwat_comp -f $EXTRA_DELTA_FILE
 echo "travis_fold:end:init-qwat"
 
 # Set the baseline for the comp database
-pum baseline -p qwat_comp -t qwat_sys.info -d $TRAVIS_BUILD_DIR/update/delta/ -b $VERSION
+pum baseline -p qwat_comp -t qwat_sys.info -d $DELTA_DIRS -b $VERSION
 
 # Run test_and_upgrade
 printf "travis_fold:start:test-and-upgrade\nRun test and upgrade"
-yes | pum test-and-upgrade -pp qwat_prod -pt qwat_test -pc qwat_comp -t qwat_sys.info -d $TRAVIS_BUILD_DIR/update/delta/ -f /tmp/qwat_dump -i views rules
+yes | pum test-and-upgrade -pp qwat_prod -pt qwat_test -pc qwat_comp -t qwat_sys.info -d $DELTA_DIRS -f /tmp/qwat_dump -i views rules
 echo "travis_fold:end:test-and-upgrade"
 
 # Run a last check between qwat_prod and qwat_comp

--- a/.build/travis_script.sh
+++ b/.build/travis_script.sh
@@ -49,7 +49,7 @@ pum restore -p qwat_prod qwat_dump.backup
 pum baseline -p qwat_prod -t qwat_sys.info -d $DELTA_DIRS -b 1.2.1
 
 # Run init_qwat.sh to create the last version of qwat db used as the comp database
-printf "travis_fold:start:init_qwat\nInitialize database"
+printf "travis_fold:start:init-qwat\nInitialize database"
 $TRAVIS_BUILD_DIR/init_qwat.sh -p qwat_comp -s 21781 -r -n
 psql service=qwat_comp -f $EXTRA_DELTA_FILE
 echo "travis_fold:end:init-qwat"


### PR DESCRIPTION
The latest version of Pum ([0.5.11](https://pypi.python.org/pypi/pum/0.5.11)) supports multiple delta directories on the command line (`-d DIR1 DIR2`). We will that for extensions and customizations with their own delta directories.

This PR modifies the Travis script to start exercising this new Pum feature. For now a dummy delta dir (`/tmp/delta`) with a dummy delta files (`SELECT 1;`) are used. When deltas will be added for the SIRE extension we will be able to test with these deltas instead of the dummy one added here.