### PR TITLE
WIP: Make changes for Pum 0.6

### DIFF
--- a/init_qwat.sh
+++ b/init_qwat.sh
@@ -97,7 +97,7 @@ done
 
 
 # Check if pum is installed (will fail and stop the script in case of error)
-PUM_VERSION=$(pum -v)
+PUM_VERSION=$(pum -V)
 echo "PUM version: $PUM_VERSION"
 echo
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pum==0.5.13
+https://github.com/elemoine/pum/archive/ele_regression.zip#egg=pum
 psycopg2-binary
 pyyaml

--- a/update/upgrade_db.sh
+++ b/update/upgrade_db.sh
@@ -60,7 +60,7 @@ shift
 done
 
 # Check if pum is installed
-PUM_VERSION=$(pum -v)
+PUM_VERSION=$(pum -V)
 if [[ $PUM_VERSION == '' ]]; then
     printf "\t${RED}PUM is not installed${NC}\n"
     echo "Please install PUM compatible with Python 3 (pip install pum)"


### PR DESCRIPTION
In Pum 0.6 (and higher) the version flag was changed for `-v` to `-V`. This PR accomodates for this change.

Also, there's a regression in Pum 0.6. See https://github.com/opengisch/pum/pull/38. Commit f3e233c tests that the fix for the regression does work for QWAT. I'll remove that commit when there's a new Pum release on pypi.