### PR TITLE
Fix #187 valve altitude

### DIFF
--- a/update/delta/delta_1.3.3_003_fix_valve_altitude.sql
+++ b/update/delta/delta_1.3.3_003_fix_valve_altitude.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE FUNCTION qwat_od.ft_valve_main_altitude() RETURNS TRIGGER AS
+$BODY$
+	DECLARE
+	BEGIN
+	-- altitude is prioritary on Z value of the geometry (if both changed, only altitude is taken into account)
+	IF TG_OP = 'INSERT' THEN
+		IF NEW.altitude IS NOT NULL THEN
+			NEW.geometry := ST_SetSRID(ST_MakePoint( ST_X(NEW.geometry), ST_Y(NEW.geometry), NEW.altitude ), ST_SRID(NEW.geometry));
+		ELSIF ST_Z(NEW.geometry) IS NOT NULL THEN
+			NEW.altitude := ST_Z(NEW.geometry);
+		END IF;
+	ELSIF TG_OP = 'UPDATE' THEN
+		IF NEW.altitude <> OLD.altitude THEN
+			NEW.geometry := ST_SetSRID(ST_MakePoint( ST_X(NEW.geometry), ST_Y(NEW.geometry), NEW.altitude ), ST_SRID(NEW.geometry));
+		ELSIF ST_Z(NEW.geometry) <> ST_Z(OLD.geometry) THEN
+			NEW.altitude := ST_Z(NEW.geometry);
+		END IF;
+	END IF;
+	RETURN NEW;
+	END;
+$BODY$
+LANGUAGE plpgsql;


### PR DESCRIPTION
Fix https://github.com/qwat/qwat-data-model/issues/187

SRID was missing:
```
ERROR: Geometry SRID (0) does not match column SRID (21781)
État SQL :22023
Contexte : PL/pgSQL function qwat_od.ft_valve_main_altitude() line 16 at assignment
```

And update the logic for insert