### PR TITLE
Add 'Compteur de chantier' for part_type and EN/RO translations

### DIFF
--- a/update/delta/delta_1.3.3_005_add_compteurdechantier_part_type.sql
+++ b/update/delta/delta_1.3.3_005_add_compteurdechantier_part_type.sql
@@ -1,1 +1,1 @@
-INSERT INTO qwat_vl.part_type (id, value_en, value_fr, vl_active) VALUES (9220, 'site water meter', 'compteur de chantier', true)
+INSERT INTO qwat_vl.part_type (id, value_en, value_fr, value_ro, vl_active) VALUES (9220, 'site water meter', 'compteur de chantier', 'contor de construcții', true)

--- a/update/delta/delta_1.3.3_005_add_compteurdechantier_part_type.sql
+++ b/update/delta/delta_1.3.3_005_add_compteurdechantier_part_type.sql
@@ -1,0 +1,1 @@
+INSERT INTO qwat_vl.part_type (id, value_en, value_fr, vl_active) VALUES (9220, 'site water meter', 'compteur de chantier', true)

--- a/value_lists/vl_part_type.sql
+++ b/value_lists/vl_part_type.sql
@@ -22,4 +22,4 @@ INSERT INTO qwat_vl.part_type (id, value_en, value_fr, value_ro, vl_active) VALU
 INSERT INTO qwat_vl.part_type (id, value_en, value_fr, value_ro, vl_active) VALUES (9208, 'unknown fitting', 'raccord inconnu', 'fiting nedeterminat', true);
 INSERT INTO qwat_vl.part_type (id, value_en, value_fr, value_ro, vl_active) VALUES (9209, 'manometer', 'manomètre', 'manometru', true);
 INSERT INTO qwat_vl.part_type (id, value_en, value_fr, value_ro, vl_active) VALUES (9210, 'flow meter', 'débitmètre', 'debitmetru', true);
-
+INSERT INTO qwat_vl.part_type (id, value_en, value_fr, vl_active) VALUES (9220, 'site water meter', 'compteur de chantier', true)

--- a/value_lists/vl_part_type.sql
+++ b/value_lists/vl_part_type.sql
@@ -22,4 +22,4 @@ INSERT INTO qwat_vl.part_type (id, value_en, value_fr, value_ro, vl_active) VALU
 INSERT INTO qwat_vl.part_type (id, value_en, value_fr, value_ro, vl_active) VALUES (9208, 'unknown fitting', 'raccord inconnu', 'fiting nedeterminat', true);
 INSERT INTO qwat_vl.part_type (id, value_en, value_fr, value_ro, vl_active) VALUES (9209, 'manometer', 'manomètre', 'manometru', true);
 INSERT INTO qwat_vl.part_type (id, value_en, value_fr, value_ro, vl_active) VALUES (9210, 'flow meter', 'débitmètre', 'debitmetru', true);
-INSERT INTO qwat_vl.part_type (id, value_en, value_fr, vl_active) VALUES (9220, 'site water meter', 'compteur de chantier', true)
+INSERT INTO qwat_vl.part_type (id, value_en, value_fr, value_ro, vl_active) VALUES (9220, 'site water meter', 'compteur de chantier', 'contor de construcții', true)


### PR DESCRIPTION
qwat_vl.part_type: add a new "Compteur de chantier" entry

I'm not sure about the EN translation.

@tudorbarascu is "contor de construcții" corrects for RO translation?

cc @kandre @ponceta 