### PR TITLE
Fix the sigip customization structure

### DIFF
--- a/.build/customizations/sigip/damage/damage.sql
+++ b/.build/customizations/sigip/damage/damage.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS qwat_od.damage
+CREATE TABLE qwat_od.damage
 (
   id serial NOT NULL,
   fk_cause integer NOT NULL,

--- a/.build/customizations/sigip/init.sh
+++ b/.build/customizations/sigip/init.sh
@@ -73,4 +73,13 @@ if [[ "$DROPSCHEMA" -eq 1 ]]; then
          -c "DROP SCHEMA IF EXISTS qwat_sigip CASCADE"
 fi
 
-PGSERVICE=${PGSERVICE} SRID=${SRID} ${DIR}/inserts.sh
+# create the qwat_sigip schema
+psql service=${PGSERVICE} -c "CREATE SCHEMA IF NOT EXISTS qwat_sigip;"
+
+# add the qwat_od.damage table
+psql service=${PGSERVICE} -v ON_ERROR_STOP=1 -v SRID=$SRID -f ${DIR}/damage/damage.sql
+
+# create the sigip views
+PGSERVICE=${PGSERVICE} SRID=${SRID} ${DIR}/insert_views.sh
+
+exit 0

--- a/.build/customizations/sigip/insert_views.sh
+++ b/.build/customizations/sigip/insert_views.sh
@@ -5,10 +5,6 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-psql service=${PGSERVICE} -c "CREATE SCHEMA IF NOT EXISTS qwat_sigip;"
-
-psql -v ON_ERROR_STOP=1 -v SRID=$SRID -f ${DIR}/damage/damage.sql
-
 psql -v ON_ERROR_STOP=1 -v SRID=$SRID -f ${DIR}/views/damage.sql
 psql -v ON_ERROR_STOP=1 -v SRID=$SRID -f ${DIR}/views/hydrant.sql
 psql -v ON_ERROR_STOP=1 -v SRID=$SRID -f ${DIR}/views/installation.sql

--- a/.build/customizations/sigip/rewrite_views.sh
+++ b/.build/customizations/sigip/rewrite_views.sh
@@ -5,6 +5,6 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 psql service=${PGSERVICE} -v ON_ERROR_STOP=1 -f ${DIR}/drop_views.sql
-PGSERVICE=${PGSERVICE} SRID=${SRID} ${DIR}/inserts.sh
+PGSERVICE=${PGSERVICE} SRID=${SRID} ${DIR}/insert_views.sh
 
 exit 0


### PR DESCRIPTION
This (hopefully) fixes the Travis build errors observed in #271, by properly structuring the sigip customization used in the tests.

Let's see what Travis says.