### PR TITLE
Add default sequence to survey points

### DIFF
--- a/ordinary_data/surveypoint/od_surveypoint.sql
+++ b/ordinary_data/surveypoint/od_surveypoint.sql
@@ -8,7 +8,7 @@
 /* create */
 CREATE TABLE qwat_od.surveypoint ();
 
-ALTER TABLE qwat_od.surveypoint ADD COLUMN id integer NOT NULL REFERENCES qwat_od.surveypoint(id) PRIMARY KEY;
+ALTER TABLE qwat_od.surveypoint ADD COLUMN id serial PRIMARY KEY;
 ALTER TABLE qwat_od.surveypoint ADD COLUMN fk_survey_type   integer not null;
 ALTER TABLE qwat_od.surveypoint ADD COLUMN fk_worker        integer;
 ALTER TABLE qwat_od.surveypoint ADD COLUMN code             varchar(50);

--- a/update/delta/delta_1.3.3_014_add_surveypoints_sequence.sql
+++ b/update/delta/delta_1.3.3_014_add_surveypoints_sequence.sql
@@ -1,3 +1,4 @@
 CREATE SEQUENCE qwat_od.surveypoint_id_seq;
 ALTER TABLE qwat_od.surveypoint ALTER COLUMN id SET DEFAULT nextval('qwat_od.surveypoint_id_seq'::regclass);
 ALTER TABLE qwat_od.surveypoint DROP CONSTRAINT surveypoint_id_fkey;
+SELECT setval('qwat_od.surveypoint_id_seq', COALESCE((SELECT max(id)+1 FROM qwat_od.surveypoint), 1), false);

--- a/update/delta/delta_1.3.3_014_add_surveypoints_sequence.sql
+++ b/update/delta/delta_1.3.3_014_add_surveypoints_sequence.sql
@@ -1,2 +1,3 @@
 CREATE SEQUENCE qwat_od.surveypoint_id_seq;
 ALTER TABLE qwat_od.surveypoint ALTER COLUMN id SET DEFAULT nextval('qwat_od.surveypoint_id_seq'::regclass);
+ALTER TABLE qwat_od.surveypoint DROP CONSTRAINT surveypoint_id_fkey;

--- a/update/delta/delta_1.3.3_014_add_surveypoints_sequence.sql
+++ b/update/delta/delta_1.3.3_014_add_surveypoints_sequence.sql
@@ -1,0 +1,2 @@
+CREATE SEQUENCE qwat_od.surveypoint_id_seq;
+ALTER TABLE qwat_od.surveypoint ALTER COLUMN id SET DEFAULT nextval('qwat_od.surveypoint_id_seq'::regclass);


### PR DESCRIPTION
Follow-up to #185 

It seems alright from my point of view. However, I didn't understood what was the purpose of the ``ALTER TABLE qwat_od.surveypoint ADD COLUMN id integer NOT NULL REFERENCES qwat_od.surveypoint(id) PRIMARY KEY;`` old construct, so there must be something I'm missing.
Thoughts?