### PR TITLE
Remove hardcored SRS

### DIFF
--- a/update/delta/post-all.py
+++ b/update/delta/post-all.py
@@ -1,17 +1,26 @@
 from pum.core.deltapy import DeltaPy
 import os
+import subprocess
+
 
 class RecreateViewsAndFunctions(DeltaPy):
 
     def run(self):
+        srid = subprocess.check_output("""psql service={} -c "SELECT DISTINCT srid FROM public.geometry_columns 
+                                                             WHERE f_table_schema = 'qwat_od'" -q -t -A""".format(self.pg_service), shell=True)
+
+        srid = int(srid)
+
         self.write_message("Reloading views and functions")
 
         views_sh = os.path.join(self.delta_dir, '..', '..', 'ordinary_data', 'views',
                                 'rewrite_views.sh')
-        views_cmd = 'PGSERVICE={} SRID=21781 {}'.format(self.pg_service, views_sh)
+        views_cmd = 'PGSERVICE={} SRID={} {}'.format(
+            self.pg_service, srid, views_sh)
         functions_sh = os.path.join(self.delta_dir, '..', '..', 'ordinary_data', 'functions',
                                     'rewrite_functions.sh')
-        functions_cmd = 'PGSERVICE={} SRID=21781 {}'.format(self.pg_service, functions_sh)
+        functions_cmd = 'PGSERVICE={} SRID={} {}'.format(
+            self.pg_service, srid, functions_sh)
         os.system(views_cmd)
         os.system(functions_cmd)
 


### PR DESCRIPTION
For the moment, it is not possible to pass variables to pum. While waiting for an evolution of pum, I propose to get the SRID from the database. This is only one way among many to achieve this workaround. There are others.