### PR TITLE
Update fn_pipe_get_id.sql using st_dwithin rather than st_intersects

### DIFF
--- a/datamodel/ordinary_data/functions/fn_pipe_get_id.sql
+++ b/datamodel/ordinary_data/functions/fn_pipe_get_id.sql
@@ -13,7 +13,7 @@ $BODY$
 	BEGIN
 		_pipe_id := pipe.id FROM qwat_od.pipe 
 			JOIN qwat_vl.status ON fk_status = status.id
-			WHERE ST_Intersects(ST_Force2d(_geometry),ST_Force2d(pipe.geometry)) 
+			WHERE ST_DWithin(ST_Force2d(_geometry), ST_Force2d(pipe.geometry), 0.001)
 			ORDER BY status.active::integer DESC
 			LIMIT 1;
 		RETURN _pipe_id;


### PR DESCRIPTION
We often have the problem of _fk_pipe_ not being filled automatically. _St_dwithin_ is more tolerant than _st_intersects_. I set the tolerance to 1mm.